### PR TITLE
Add DB_FOLDER description in _scaffold/settings.py

### DIFF
--- a/apps/_scaffold/settings.py
+++ b/apps/_scaffold/settings.py
@@ -8,6 +8,8 @@ This file is provided as an example:
 import os
 # db settings
 APP_FOLDER = os.path.dirname(__file__)
+# DB_FOLDER:    Sets the place where migration files will be created
+#               and is the store location for SQLite databases
 DB_FOLDER = os.path.join(APP_FOLDER, 'databases')
 DB_URI = 'sqlite://storage.db'
 DB_POOL_SIZE = 1


### PR DESCRIPTION
As a new user I disabled this because I was using MySql and didn't know it was needed, errors forced me to turn it back on, but I didn't know why I needed it turned on.

I eventually found the description in the docs under "Other DAL constructor parameters".  

If the change is not appropriate here, perhaps add it to the examples app?