### PR TITLE
Luca host port

### DIFF
--- a/apps/_documentation/static/chapters/en/chapter-01.mm
+++ b/apps/_documentation/static/chapters/en/chapter-01.mm
@@ -2,7 +2,7 @@
 
 ### Supported platforms and prerequisites
 
-PY4WEB runs fine on Windows, MacOS and Linux. Its only prerequisite is Python 3, which must be installed in advance. 
+PY4WEB runs fine on Windows, MacOS and Linux. Its only prerequisite is Python 3, which must be installed in advance.
 
 ### Installing from pip
 
@@ -22,15 +22,15 @@ py4web-start apps
 This should produce an output like:
 
 ``
-██████╗ ██╗   ██╗██╗  ██╗██╗    ██╗███████╗██████╗ 
+██████╗ ██╗   ██╗██╗  ██╗██╗    ██╗███████╗██████╗
 ██╔══██╗╚██╗ ██╔╝██║  ██║██║    ██║██╔════╝██╔══██╗
 ██████╔╝ ╚████╔╝ ███████║██║ █╗ ██║█████╗  ██████╔╝
 ██╔═══╝   ╚██╔╝  ╚════██║██║███╗██║██╔══╝  ██╔══██╗
 ██║        ██║        ██║╚███╔███╔╝███████╗██████╔╝
-╚═╝        ╚═╝        ╚═╝ ╚══╝╚══╝ ╚══════╝╚═════╝ 
+╚═╝        ╚═╝        ╚═╝ ╚══╝╚══╝ ╚══════╝╚═════╝
 Dashboard is at: http://127.0.0.1:8000/_dashboard
-[X] loaded _dashboard     
-[X] loaded _default     
+[X] loaded _dashboard
+[X] loaded _default
 Bottle v0.12.16 server starting up (using TornadoServer())...
 Listening on http://127.0.0.1:8000/
 Hit Ctrl-C to quit.
@@ -48,7 +48,7 @@ Once py4web is installed you can access the apps at the following urls:
 
 ``
 http://localhost:8000
-http://localhost:8000/_default 
+http://localhost:8000/_default
 http://localhost:8000/_dashboard
 http://localhost:8000/{yourappname}/index
 ``
@@ -105,8 +105,8 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  -a ADDRESS, --address ADDRESS
-                        serving address
+  --host HOST           serving host
+  --port PORT           serving port
   -n NUMBER_WORKERS, --number_workers NUMBER_WORKERS
                         number of gunicorn workers
   --ssl_cert_filename SSL_CERT_FILENAME
@@ -146,7 +146,7 @@ Copy or symlink your ``apps`` folder into the gae folder, or maybe make a new ap
 Makefile
 apps
   __init__.py
-  ... your apps ... 
+  ... your apps ...
 lib
 app.yaml
 main.py

--- a/py4web/core.py
+++ b/py4web/core.py
@@ -48,8 +48,8 @@ import pydal
 import pluralize
 from pydal._compat import to_native, to_bytes
 
-__all__ = ['render', 'DAL', 'Field', 'action', 'request', 'response', 'redirect', 
-           'abort', 'HTTP', 'Session', 'Cache', 'user_in', 'Translator', 'URL', 
+__all__ = ['render', 'DAL', 'Field', 'action', 'request', 'response', 'redirect',
+           'abort', 'HTTP', 'Session', 'Cache', 'user_in', 'Translator', 'URL',
            'check_compatible', 'wsgi']
 
 DEFAULTS = dict(
@@ -288,7 +288,7 @@ class Session(Fixture):
         if hasattr(storage, '__prerequisites__'):
             self.__prerequisites__ = storage.__prerequisites__
 
-    def load(self):        
+    def load(self):
         self.local.session_cookie_name = '%s_session' % request.app_name
         self.local.changed = False
         self.local.secure = request.url.startswith('https')
@@ -575,8 +575,8 @@ def get_error_snapshot(depth=5):
         line_vars = cgitb.scanvars(
             lambda: linecache.getline(file, lnum), frame, locals)
         # Dump local variables (referenced in current line only)
-        f['vars'] = {key: repr(value) 
-                     for key, value in locals.items() 
+        f['vars'] = {key: repr(value)
+                     for key, value in locals.items()
                      if not key.startswith('__')}
         stackframes.append(f)
 
@@ -744,7 +744,7 @@ def error404(error):
 
 
 def start_server(args):
-    host, port = args.address.split(':')
+    host, port = args.host, args.port
     if args.number_workers < 1:
         bottle.run(server='tornado', host=host, port=int(port), reloader=False)
     else:
@@ -777,8 +777,10 @@ def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('apps_folder',
                         help='Path to the applications folder')
-    parser.add_argument('-a', '--address', default='127.0.0.1:8000',
-                        help='<Server Address>:<port number> or <hostname>:<port>')
+    parser.add_argument('--host', default='127.0.0.1',
+                        help='Server address (IP or hostname)')
+    parser.add_argument('--port', default='8000',
+                        help='Port number (e.g., 8000)')
     parser.add_argument('-n', '--number_workers', default=0, type=int,
                         help='Number of gunicorn workers to utilize')
     parser.add_argument('--ssl_cert_filename', default=None, type=int,
@@ -796,13 +798,14 @@ def get_args():
     parser.add_argument('-c', '--create', action='store_true', default=True,
                         help='Create missing folders and apps without prompting')
     # Parse command line arguments
-    return parser.parse_args()
+    args = parser.parse_args()
+    return args
 
 
 def initialize(**args):
     """Initialize from args"""
     for key in args:
-        os.environ['PY4WEB_' + key.upper()] = str(args[key])    
+        os.environ['PY4WEB_' + key.upper()] = str(args[key])
     apps_folder = os.environ['PY4WEB_APPS_FOLDER']
     service_folder = os.path.join(apps_folder, os.environ['PY4WEB_SERVICE_FOLDER'])
     # If the apps folder does not exist create it and populate it
@@ -845,9 +848,9 @@ def main(args=None):
     # and create any missing folders
     initialize(**args.__dict__)
     if os.path.exists(os.path.join(args.apps_folder, '_dashboard')):
-        print('Dashboard is at: http://%s/_dashboard' % args.address)
+        print('Dashboard is at: http://%s:%s/_dashboard' % (args.host, args.port))
     # start
     Reloader.import_apps()
-    start_server(args)    
+    start_server(args)
 
 


### PR DESCRIPTION
I separated the --address argument into a --host and --port one. 
I am thinking of a teaching setting; it's much easiser to tell students to use 
--port 8866 
if the default port is busy rather than having to type out the whole 
--address 127.0.0.1:8866
and it's easier for me to type as well. 
I made the change in the documentation also. 