### PR TITLE
Patch 6 - SQLFORM -> py4web.utils.form.Form

### DIFF
--- a/apps/_documentation/static/chapters/en/chapter-10.mm
+++ b/apps/_documentation/static/chapters/en/chapter-10.mm
@@ -2,3 +2,12 @@ WORK IN PROGRESS
 
 Just know that ``py4web.utils.form.Form`` is a pretty much equivalent to web2py's ``SQLFORM``.
 
+Form will accept the following:
+    - table: a DAL table or a list of fields (equivalent to old SQLFORM.factory)
+    - record: a DAL record or record id
+    - readonly: set to True to make a readonly form
+    - deletable: set to False to disallow deletion of record
+    - formstyle: a function that renders the form using helpers (FormStyleDefault)
+    - dbio: set to False to prevent any DB writes
+    - keep_values: if set to true, it remembers the values of the previously submitted form
+    - form_name: the optional name of this form

--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -107,7 +107,7 @@ def FormStyleBulma(table, vars, errors, readonly, deletable):
 
 class Form(object):
     """
-    Usage in web2py controller:
+    Usage in py4web controller:
 
        def index():
            form = Form(db.thing, record=1)
@@ -173,8 +173,8 @@ class Form(object):
             post_vars = request.forms
             self.submitted = True
             process = False
-            # We only a process a form if it is POST and the formkey matches (correct formname and crsf)
-            # Notice: we never expose the crsf uuid, we only use to sign the form uuid
+            # We only a process a form if it is a POST and the formkey matches (both the correct formname and crsf)
+            # Notice: we never expose the crsf uuid, we only use it to sign the form uuid
             if request.method == 'POST':                
                 if post_vars.get('_formkey') == self.form_name:
                     process = True

--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -122,8 +122,8 @@ class Form(object):
     - readonly: set to True to make a readonly form
     - deletable: set to False to disallow deletion of record
     - formstyle: a function that renders the form using helpers (FormStyleDefault)
-    - dbio: set to False to prevent any DB write
-    - keep_values: if set to true, it remebers the values of the previously submitted form
+    - dbio: set to False to prevent any DB writes
+    - keep_values: if set to true, it remembers the values of the previously submitted form
     - form_name: the optional name of this form
     """
 


### PR DESCRIPTION
``SQLFORM`` and py4web.utils.form.Form are equivalent, but not the same.

There are fewer arguments (based on py4web\utils\form) and some names have changed.
Updating chapter-10.mm to at least show the arguments accepted by Form
Updating form.py to correct spelling (and general English).