### PR TITLE
Update documentation, add headless option

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ password: *****
 ## Launch Arguments
 
 ```
-usage: py4web-start.py [-h] [-a ADDRESS] [-n NUMBER_WORKERS]
+usage: py4web-start.py [-h] [--host HOSTNAME] [--port PORT] [--headless] [-n NUMBER_WORKERS]
                        [--ssl_cert_filename SSL_CERT_FILENAME]
                        [--ssl_key_filename SSL_KEY_FILENAME]
                        [--service_db_uri SERVICE_DB_URI] [-d DASHBOARD_MODE]
@@ -109,8 +109,9 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  -a ADDRESS, --address ADDRESS
-                        serving address
+  --host HOSTNAME       server address (IP or hostname)
+  --port PORT           server port number (e.g., 8000)
+  --headless            hide artwork for console based servers
   -n NUMBER_WORKERS, --number_workers NUMBER_WORKERS
                         number of gunicorn workers
   --ssl_cert_filename SSL_CERT_FILENAME
@@ -135,7 +136,7 @@ py4web-start -a 127.0.0.1:8000 -d demo apps
 
 ## WSGI
 
-py4web is a WSGI application. To obtain th WSGI app simply do:
+py4web is a WSGI application. To obtain the WSGI app simply do:
 
 ```
 from py4web.core import wsgi

--- a/apps/_documentation/static/chapters/en/chapter-01.mm
+++ b/apps/_documentation/static/chapters/en/chapter-01.mm
@@ -36,13 +36,13 @@ Listening on http://127.0.0.1:8000/
 Hit Ctrl-C to quit.
 ``
 
-Here ``apps`` is the name of the folder where you keep your apps. If the folder does not exist, it is created. PY4WEB expects to find two apps in this folder: Dashboard (_dashboard) and Default (_default). If it does not find them, it installs them.
+Here ``apps`` is the name of the folder where you keep your apps. If the folder does not exist, it is created. PY4WEB expects to find two apps in this folder: **Dashboard** (_dashboard) and **Default** (_default). If it does not find them, it installs them.
 
-Mind that if you upgrade py4web, it will not automatically upgrade Dashboard and Default. You have to remove these apps for py4web to re-install them. This is a safety precaution, in case you made changes to those apps.
+Mind that if you upgrade py4web, it will not automatically upgrade **Dashboard** and **Default**. You have to remove these apps for py4web to re-install them. This is a safety precaution, in case you made changes to those apps.
 
-Dashboard is a web based IDE. Default is an app that does not nothing other than welcome the user. In general "apps/_default" can be an app or a symlink to your default app.
+**Dashboard** is a web based IDE. **Default** is an app that does not nothing other than welcome the user. In general "apps/_default" can be either an app or a symlink to your default app.
 
-Notice that some apps - like Dashboard and Default - have a special role in py4web and therefore their actual name starts with ``_`` to avoid conflicts with apps created by you.
+Notice that some apps - like **Dashboard** and **Default** - have a special role in py4web and therefore their actual name starts with ``_`` to avoid conflicts with apps created by you.
 
 Once py4web is installed you can access the apps at the following urls:
 
@@ -53,8 +53,8 @@ http://localhost:8000/_dashboard
 http://localhost:8000/{yourappname}/index
 ``
 
-Notice that ONLY the default app does not need a path prefix (``/_default`` is optional).
-Also the trailing ``/index`` is optional.
+Notice that ONLY the **Default** app does require a path prefix. In the example above ``http://localhost:8000`` and ``http://localhost:8000/_default`` are identical to py4web; all other apps require the /{appname}.
+NOTE: For all apps the trailing ``/index`` is optional.
 
 ### Installing from source
 
@@ -84,16 +84,21 @@ python3 -c "from pydal.validators import CRYPT; open('password.txt','w').write(s
 
 and then ask py4web to re-use that password:
 
-``
-py4web-start.py -p password.txt apps
-``:bash
+Pip Install:
+
+``python3 -m py4web-start -p password.txt apps``
+
+Console:
+``python3 py4web-start.py -p password.txt apps``:bash
+or
+``./py4web-start.py -p password.txt apps``:bash
 
 ### Command line options
 
 py4web provides multiple command line options which can be listed with ``-h``.
 
 ``
-usage: py4web-start.py [-h] [-a ADDRESS] [-n NUMBER_WORKERS]
+usage: py4web-start.py [-h] [--host HOSTNAME] [--port PORT] [--headless] [-n NUMBER_WORKERS]
                        [--ssl_cert_filename SSL_CERT_FILENAME]
                        [--ssl_key_filename SSL_KEY_FILENAME]
                        [--service_db_uri SERVICE_DB_URI] [-d DASHBOARD_MODE]
@@ -105,8 +110,9 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  --host HOST           serving host
-  --port PORT           serving port
+  --host HOSTNAME       server address (IP or hostname)
+  --port PORT           server port number (e.g., 8000)
+  --headless            hide artwork for console based servers
   -n NUMBER_WORKERS, --number_workers NUMBER_WORKERS
                         number of gunicorn workers
   --ssl_cert_filename SSL_CERT_FILENAME
@@ -127,7 +133,7 @@ optional arguments:
 Login into the Gcloud console (https://console.cloud.google.com/) and create a new project. You will obtain a project id that looks like "{project_name}-{number}".
 
 
-In your local fil system make a new working folder and cd into it:
+In your local file system make a new working folder and cd into it:
 
 ``
 mkdir gae
@@ -140,7 +146,7 @@ Copy the example files from py4web (assuming you have the source from github)
 cp /path/to/py4web/development_tools/gcloud/* ./
 ``
 
-Copy or symlink your ``apps`` folder into the gae folder, or maybe make a new apps folder contaning an emty ``__init__.py`` and symblink the individual apps you want to deploy. You should see the following files/folders:
+Copy or symlink your ``apps`` folder into the gae folder, or maybe make a new apps folder containing an empty ``__init__.py`` and symlink the individual apps you want to deploy. You should see the following files/folders:
 
 ``
 Makefile

--- a/apps/_documentation/static/chapters/en/chapter-11.mm
+++ b/apps/_documentation/static/chapters/en/chapter-11.mm
@@ -2,7 +2,7 @@
 
 **Warning: the API described in this chapter is new and subject to changes. Make sure you keep your code up to date**
 
-py4web comes with a an objct Auth and a system of plugins for user authentication and access control. It has the same name than the corresponding web2py one and serves the same purpose but the API and internal design is very different.
+py4web comes with a an object Auth and a system of plugins for user authentication and access control. It has the same name as the corresponding web2py one and serves the same purpose but the API and internal design is very different.
 
 To use it, first of all you need to import it, instantiate it, configure it, and enable it.
 
@@ -13,7 +13,7 @@ auth = Auth(session, db)
 auth.enable()
 ``:python
 
-The import step is obvious. The second step does not perform any opeation other than telling the Auth object which session object to use and which database to use. Auth data is stored in ``session['user']`` and, if a user is logged in, the user id is stored in session['user']['id']. The db object is used to store persistent info about the user in a table ``auth_user`` with the following fields:
+The import step is obvious. The second step does not perform any operation other than telling the Auth object which session object to use and which database to use. Auth data is stored in ``session['user']`` and, if a user is logged in, the user id is stored in session['user']['id']. The db object is used to store persistent info about the user in a table ``auth_user`` with the following fields:
 
 - username
 - email
@@ -21,7 +21,7 @@ The import step is obvious. The second step does not perform any opeation other 
 - first_name
 - last_name
 - sso_id (used for single sign on, see later)
-- action_token (used to verify email, block usrs, and otehr tasks, also see later).
+- action_token (used to verify email, block users, and other tasks, also see later).
 
 If the ``auth_user`` table does not exist it is created.
 
@@ -43,7 +43,7 @@ Those marked with a (+) require a logged in user.
 
 ## Auth UI
 
-You can create your own web UI to login users using the above APIs but py4web povides one as an example, implemented in the following files:
+You can create your own web UI to login users using the above APIs but py4web provides one as an example, implemented in the following files:
 
 - _scaffold/templates/auth.html
 - _scaffold/static/components/auth.js
@@ -67,13 +67,13 @@ The component files (js/html) define a Vue component ``<auth/>`` which is used i
 [[end]]
 ``:html
 
-You can pretty much use this file un-modified. It extends the current layout and embeds the ``<auth/>`` component into the page. It then uses ``utils.app().start();`` (py4web magic) to render the content of ``<div id="vue">...</div>`` using Vue.js. ``components/auth.js`` also automatically loads ``components/auth.html`` into the component placeholder (more py4web magic). The component is responsible for rendering the login/register/etc forms using ractive html and GETing/POSTing data to the Auth service APIs.
+You can pretty much use this file un-modified. It extends the current layout and embeds the ``<auth/>`` component into the page. It then uses ``utils.app().start();`` (py4web magic) to render the content of ``<div id="vue">...</div>`` using Vue.js. ``components/auth.js`` also automatically loads ``components/auth.html`` into the component placeholder (more py4web magic). The component is responsible for rendering the login/register/etc forms using reactive html and GETing/POSTing data to the Auth service APIs.
 
-If you need to change th style of the component you can edit "components/auth.html" to suit your needs. It is mostly HTML with some spcial Vue ``v-*`` tags.
+If you need to change the style of the component you can edit "components/auth.html" to suit your needs. It is mostly HTML with some special Vue ``v-*`` tags.
 
 ## Using Auth
 
-There two ways to use th Auth object into an action:
+There two ways to use the Auth object in an action:
 
 ``
 @action('index')
@@ -83,7 +83,7 @@ def index():
     return 'hello {first_name}'.format(**user) if user else 'not logged in'
 ``:python
 
-With ``@action.uses(auth)`` we tell py4web that this action needs to have information about the user, try parse the session for a user session.
+With ``@action.uses(auth)`` we tell py4web that this action needs to have information about the user, then try to parse the session for a user session.
 
 ``
 @action('index')
@@ -93,38 +93,38 @@ def index():
     return 'hello {first_name}'.format(**user)'
 ``:python
 
-Here ``@action.uses(auth.user)`` tells py4web that this action requires a logged in user and ahould redirect to login otherwise.
+Here ``@action.uses(auth.user)`` tells py4web that this action requires a logged in user and should redirect to login if no user is logged in.
 
 ## Auth Plugins
 
-Plugins are defined in "py4web/utils/auth_plugins" and they have a hierachical structures. Some are exclusive and some are not. For example default, LDAP, PAM, and SAML ones are exclusive (the developer has to pick one). Default, Google, Facebook, and Tritter OAuth are not exclusive (the developer can pick them all and the user gets to choose using the UI).
+Plugins are defined in "py4web/utils/auth_plugins" and they have a hierachical structures. Some are exclusive and some are not. For example, default, LDAP, PAM, and SAML are exclusive (the developer has to pick one). Default, Google, Facebook, and Twitter OAuth are not exclusive (the developer can pick them all and the user gets to choose using the UI).
 
 The ``<auth/>`` components will automatically adapt to display login forms as required by the installed plugins.
 
-**At this time we cannot guarantee that the following plugins work well. They hav been ported from web2py where the do work but they need testing**
+**At this time we cannot guarantee that the following plugins work well. They have been ported from web2py where they do work but testing is still needed**
 
 ### PAM
 
 Configuring PAM is the easiest:
 
-``            
+``
 from py4web.utils.auth_plugins.pam_plugin import PamPlugin
 auth.register_plugin(PamPlugin())
 ``:python
 
-This one like all plugins must be imported and registered. Once registered the UI (components/auth) and the RESTful APIs know how to handle it. The constructor of this plugins does not require any argument but other plugins do.
+This one like all plugins must be imported and registered. Once registered the UI (components/auth) and the RESTful APIs know how to handle it. The constructor of this plugins does not require any arguments (where other plugins do).
 
 The ``auth.register_plugin(...)`` **must** come before the ``auth.enable()`` since it makes no sense to expose APIs before desired plugins are mounted.
 
 ### LDAP
 
-``                
+``
 from py4web.utils.auth_plugins.ldap_plugin import LDAPPlugin
 LDAP_SETTING = {
     'mode': 'ad',
-    'server': 'my.domain.controller',                                                                  
+    'server': 'my.domain.controller',
     'base_dn': 'ou=Users,dc=domain,dc=com'
-} 
+}
 auth.register_plugin(LDAPPlugin(**LDAP_SETTINGS))
 ``:python
 
@@ -154,14 +154,14 @@ The client id and client secret must be provided by Facebook.
 
 ### Tags and Permissions
 
-Py4web does not have the concept of groups as web2py does. Experience showed that while that mechanism is powerful it suffers from two problems: it is overkill for most apps, and it is not flxible enough for very complex apps. Py4web provides a general purpose tagging mechanism that allows to tag any record of any table and check for existance of tags and for records having a tag. Group membership can be thought of a type of tag that we apply to usrs. Permissions can also be tags. Developer are free to create their own logic on top of the tagging system. 
+Py4web does not have the concept of groups as web2py does. Experience showed that while that mechanism is powerful it suffers from two problems: it is overkill for most apps, and it is not flexible enough for very complex apps. Py4web provides a general purpose tagging mechanism that allows the developer to tag any record of any table, check for the existence of tags, as well as checking for records containing a tag. Group membership can be thought of a type of tag that we apply to users. Permissions can also be tags. Developer are free to create their own logic on top of the tagging system.
 
 To use the tagging system you need to create an object to tag a table:
 ``
 groups = Tags(db.auth_user)
 ``:python
 
-Then you can apply one or more tags to records of the table and remove them:
+Then you can add one or more tags to records of the table as well as remove existing tags:
 
 ``
 groups.add(user.id, 'manager')
@@ -169,18 +169,18 @@ groups.add(user.id, ['dancer', 'teacher'])
 groups.remove(user.id, 'dancer')
 ``:python
 
-Here the use case is group based access control so you can check if a user is a member of a group:
+Here the use case is group based access control where the developer first checks if a user is a member of the ``'manager'`` group, if the user is not a manager (or no one is logged in) py4web redirects to the ``'not authorized url'``. If the user is in the correct group then py4web displays 'hello manager':
 
 ``
 @action('index')
 @action.uses(auth.user)
 def index():
     if not 'manager' in groups.get(auth.get_user()['id']):
-        rediect(URL('not_authorized'))
+        redirect(URL('not_authorized'))
     return 'hello manager'
 ``:python
 
-And you ask query the db for all records having the desired tag(s):
+Here the developer queries the db for all records having the desired tag(s):
 
 ``
 @action('find_by_tag/{group_name}')
@@ -190,7 +190,7 @@ def find(group_name):
     return {'users': users}
 ``:python
 
-We leave it to you as an excersice to create a fixture ``has_membership`` to allow the following syntax:
+We leave it to you as an exersize to create a fixture ``has_membership`` to enable the following syntax:
 
 ``
 @action('index')
@@ -199,7 +199,7 @@ def index():
     return 'hello teacher'
 ``:python
 
-**Important:** Tags are automatically hierarchical. For example, if a user has a group tag 'teacher/high-school/physics', then all the following seaches will return the user:
+**Important:** ``Tags`` are automatically hierarchical. For example, if a user has a group tag 'teacher/high-school/physics', then all the following seaches will return the user:
 
 - `` groups.find('teacher/high-school/physics')``
 - `` groups.find('teacher/high-school')``
@@ -207,7 +207,7 @@ def index():
 
 This means that slashes have a special meaning for tags. Slahes at the beginning or the end of a tag are optional. All other chars are allowed on equal footing.
 
-Notice that one table can have mutpliple associated Tags objects. The name groups here is completely arbitary but has a spacific semantic meaning. Different Tags objects are orthogonal to each other. The limit to their use is your creativity.
+Notice that one table can have multiple associated ``Tags`` objects. The name groups here is completely arbitary but has a specific semantic meaning. Different ``Tags`` objects are orthogonal to each other. The limit to their use is your creativity.
 
 For example you could create a table groups:
 
@@ -225,7 +225,7 @@ permissions = Tags(db.auth_groups)
 Then create a zapper group, give it a permission, and make a user member of the group:
 
 ``
-zap_id = db.auth_group.insert(name='zapper', desctiption='can zap database')
+zap_id = db.auth_group.insert(name='zapper', description='can zap database')
 permissions.add(zap_id, 'zap database')
 groups.add(user.id, 'zapper')
 ``:python
@@ -246,4 +246,3 @@ def zap():
 ``:python
 
 Notice here ``permissions.find(permission)`` generates a query for all groups with the permission and we further filter those groups for those the current user is member of. We count them and if we find any, then the user has the permission.
-

--- a/py4web/core.py
+++ b/py4web/core.py
@@ -784,6 +784,8 @@ def get_args():
                         help='Server address (IP or hostname)')
     parser.add_argument('--port', default='8000',
                         help='Port number (e.g., 8000)')
+    parser.add_argument('--headless', default=False, action='store_true',
+                        help='Hide artwork for console access')
     parser.add_argument('-n', '--number_workers', default=0, type=int,
                         help='Number of gunicorn workers to utilize')
     parser.add_argument('--ssl_cert_filename', default=None, type=int,
@@ -839,8 +841,15 @@ def initialize(**args):
 def main(args=None):
     """The main entry point: Start the server and create folders"""
     # Store args in the action to make them visible
-    print(ART)
     action.args = args = args or get_args()
+    if args.headless:
+        headless = True
+    else:
+        headless = False
+    if not headless:
+        print(ART)
+    else:
+        print('')  # Insert a blank line to improve readability
     # If we know where the password is stored, read it, otherwise ask for one
     if args.dashboard_mode not in ('demo', 'none') and not os.path.exists(args.password_file):
         password = getpass.getpass('Choose a one-time dashboard password: ')


### PR DESCRIPTION
Running Py4Web from a headless (no video card) server causes an exception due to unknown 
encoding for Py4Web art.  added a --headless argument to skip py4web.core's print(ART) when specified

**core.py:**
 - Add headless argument code to core - main()
 - Add headless argument code to core - get_args()  
 - Add missing 'e' from wsgi() docstring

**Update Readme.md:**
 - Add host and port arguments from #80 to readme.md
 - Add headless argument to readme.md

**Update docs:**
1. chapter 01.mm:
    - English and spelling fixes
    - Add new launch arguments:
        - host
        - port
        - headless
2. chapter-11.mm:
    - English and spelling fixes

