### PR TITLE
Work on form validation

### DIFF
--- a/apps/_documentation/static/chapters/en/chapter-10.mm
+++ b/apps/_documentation/static/chapters/en/chapter-10.mm
@@ -2,12 +2,79 @@ WORK IN PROGRESS
 
 Just know that ``py4web.utils.form.Form`` is a pretty much equivalent to web2py's ``SQLFORM``.
 
-Form will accept the following:
-    - table: a DAL table or a list of fields (equivalent to old SQLFORM.factory)
-    - record: a DAL record or record id
-    - readonly: set to True to make a readonly form
-    - deletable: set to False to disallow deletion of record
-    - formstyle: a function that renders the form using helpers (FormStyleDefault)
-    - dbio: set to False to prevent any DB writes
-    - keep_values: if set to true, it remembers the values of the previously submitted form
-    - form_name: the optional name of this form
+The `Form` constructor accepts the following arguments:
+
+``
+Form(self,
+     table,
+     record=None,
+     readonly=False,
+     deletable=True,
+     formstyle=FormStyleDefault,
+     dbio=True,
+     keep_values=False,
+     form_name=False,
+     hidden=None,
+     before_validate=None):
+``:python
+
+Where:
+
+- `table`: a DAL table or a list of fields (equivalent to old SQLFORM.factory)
+- `record`: a DAL record or record id
+- `readonly`: set to True to make a readonly form
+- `deletable`: set to False to disallow deletion of record
+- `formstyle`: a function that renders the form using helpers (FormStyleDefault)
+- `dbio`: set to False to prevent any DB writes
+- `keep_values`: if set to true, it remembers the values of the previously submitted form
+- `form_name`: the optional name of this form
+- `hidden`: a dictionary of hidden fields that is added to the form
+- `before_validate`: an optional validator.
+
+## Example
+
+Here is a simple example of a custom form not using database access.
+We declare an endpoint `/form_example`, which will be used both for the GET and for the POST of the form:
+
+``
+@action('form_example', method=['GET', 'POST'])
+@action.uses('form_example.html', session)
+def form_example():
+    form = Form([
+        Field('product_name'),
+        Field('product_quantity', 'integer')],
+        formstyle=FormStyleBulma)
+    if form.accepted:
+        # Do something with form.vars['product_name'] and form.vars['product_quantity']
+        redirect(URL('index'))
+    return dict(form=form)
+``:python
+
+The form can be displayed in the template simply using `[[=form]]`.
+
+## Form validation
+
+The validation of form input can be done in two ways.  One can define `requires` attributes of `Field`, or one can define explicitly a validation function.  To do the latter, we pass to `validate` a function that takes the form and returns a dictionary, mapping field names to errors.  If the dictionary is non-empty, the errors will be displayed to the user, and no database I/O will take place.
+
+Here is an example:
+
+``
+def check_nonnegative_quantity(form):
+    errors = {}
+    if form.vars['product_quantity'] < 0:
+        errors['product_quantity'] = T('The product quantity cannot be negative')
+    return errors
+
+@action('form_example', method=['GET', 'POST'])
+@action.uses('form_example.html', session)
+def form_example():
+    form = Form([
+        Field('product_name'),
+        Field('product_quantity', 'integer')],
+        validation=check_nonnegative_quantity,
+        formstyle=FormStyleBulma)
+    if form.accepted:
+        # Do something with form.vars['product_name'] and form.vars['product_quantity']
+        redirect(URL('index'))
+    return dict(form=form)
+``:python

--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -137,7 +137,7 @@ class Form(object):
                  keep_values=False,
                  form_name=False,
                  hidden=None,
-                 before_validate=None):
+                 validation=None):
 
         if isinstance(table, list):
             dbio = False
@@ -182,8 +182,6 @@ class Form(object):
                     process = True
             if process:
                 if not post_vars.get('_delete'):
-                    if before_validate:
-                        self.errors = before_validate(self.record, post_vars)
                     for field in self.table:
                         if field.writable:
                             value = post_vars.get(field.name)
@@ -202,6 +200,8 @@ class Form(object):
                             self.vars[field.name] = value
                             if error:
                                 self.errors[field.name] = error
+                    if len(self.errors) == 0 and validation:
+                        self.errors = validation(self)
                     if self.record:
                         self.vars['id'] = self.record.id
                     if not self.errors:


### PR DESCRIPTION
This is not ready to be accepted, because the problem is that form.vars are NOT of the appropriate type, as they used to be in web2py.  That is, if I define a field

Field('product_quantity', 'integere')

then 

form.vars['product_quantity'] is NOT an integer; it is still a string.  I am wondering whether this difference is intentional. 