### PR TITLE
Fixed bug in URL helper

### DIFF
--- a/py4web/core.py
+++ b/py4web/core.py
@@ -371,8 +371,8 @@ def URL(*parts, vars=None, hash=None, scheme=False):
     prefix = '/%s/' % request.app_name if request.app_name != '_default' else '/'
     broken_parts = []
     for part in parts:
-        broken_parts += part.split('/')
-    url = prefix + '/'.join(map(lambda x : urllib.parse.quote(str(x)), broken_parts))
+        broken_parts += str(part).split('/')
+    url = prefix + '/'.join(map(lambda x : urllib.parse.quote(x), broken_parts))
     if vars:
         url += '?' + '&'.join('%s=%s' % (
             k, urllib.parse.quote(str(v))) for k, v in vars.items())
@@ -695,7 +695,7 @@ class Reloader:
                            'action': func.__name__})
         Reloader.ROUTES = sorted(routes, key=lambda item: item['rule'])
         ICECUBE.update(threadsafevariable.ThreadSafeVariable.freeze())
-        
+
     @staticmethod
     def import_app(app_name):
         folder = os.environ['PY4WEB_APPS_FOLDER']

--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -202,7 +202,7 @@ class Form(object):
                                 self.errors[field.name] = error
                     if validation:
                         validation(self)
-                    if self.record:
+                    if self.record and dbio:
                         self.vars['id'] = self.record.id
                     if not self.errors:
                         self.accepted = True


### PR DESCRIPTION
A part is not necessarily a string; it can be for example (and commonly) a reference type in dal, or a number.  So we need to call str() before we split it according to '/'. 
