### PR TITLE
Fixed error in form processing when not dbio

### DIFF
--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -202,7 +202,7 @@ class Form(object):
                                 self.errors[field.name] = error
                     if validation:
                         validation(self)
-                    if self.record:
+                    if self.record and dbio:
                         self.vars['id'] = self.record.id
                     if not self.errors:
                         self.accepted = True


### PR DESCRIPTION
If there is no database io, there may be no self.record.id.  An input record might have been passed simply to initialize the values of the form, but the form might correspond to no database table.
