### PR TITLE
Add ability to edit json fields from dashboard

### DIFF
--- a/apps/_dashboard/static/components/mtable.html
+++ b/apps/_dashboard/static/components/mtable.html
@@ -46,7 +46,7 @@
               {{ option.text }}
             </option>
           </select>
-          <textarea class="textarea" v-else-if="field.type=='json'" @input="function(event){item[field.name] = event.target.value}" v-bind:readonly="!editable">{{item[field.name]}}</textarea>
+          <textarea class="textarea" v-else-if="field.type=='json'" @input="function(event){item[field.name] = parse_and_validate_json(event)}" v-bind:readonly="!editable">{{item[field.name]}}</textarea>
           <div class="error" v-if="editable && field.name in errors">{{errors[field.name]}}</div>
         </td>
       </tr>

--- a/apps/_dashboard/static/components/mtable.html
+++ b/apps/_dashboard/static/components/mtable.html
@@ -46,6 +46,7 @@
               {{ option.text }}
             </option>
           </select>
+          <textarea class="textarea" v-else-if="field.type=='json'" @input="function(event){item[field.name] = event.target.value}" v-bind:readonly="!editable">{{item[field.name]}}</textarea>
           <div class="error" v-if="editable && field.name in errors">{{errors[field.name]}}</div>
         </td>
       </tr>

--- a/apps/_dashboard/static/components/mtable.js
+++ b/apps/_dashboard/static/components/mtable.js
@@ -103,6 +103,16 @@
         }
     }
 
+    mtable.methods.parse_and_validate_json = function(event){
+        try {
+            event.target.style.borderColor = "";
+            return JSON.parse(event.target.value);
+        }
+        catch{
+            event.target.style.borderColor = "#ff0000";
+        }
+    }
+
     mtable.methods.trash = function (item) {
         if (window.confirm("Really delete record?")) {
             let url = this.url + '/' + item.id;            

--- a/apps/examples/models.py
+++ b/apps/examples/models.py
@@ -10,6 +10,7 @@ db.define_table(
     "person",
     Field("name", requires=IS_NOT_IN_DB(db, "person.name"), label=T("name")),
     Field("job", requires=IS_NOT_EMPTY(), label=T("job")),
+    Field("resume", "json", label=T('resume'), default=[]),
     format="%(name)s",
 )
 
@@ -32,7 +33,22 @@ db.define_table(
 )
 
 if not db(db.person).count():
-    db.person.insert(name="Clark Kent", job="Journalist")
+    db.person.insert(
+        name="Clark Kent",
+        job="Journalist",
+        resume=[
+            {
+                "start_date": "2019-12-20",
+                "end_date": "2020-01-20",
+                "company": "Save The World Srl",
+            },
+            {
+                "start_date": "2020-02-01",
+                "end_date": "2020-03-15",
+                "company": "SuperHeroes Services Srl",
+            },
+        ],
+    )
     db.person.insert(name="Peter Park", job="Photographer")
     db.person.insert(name="Bruce Wayne", job="CEO")
     db.superhero.insert(name="Superman", real_identity=1)


### PR DESCRIPTION
This PR adds a minimum implementation for the `json` field in `_dashboard`, and also adds a `json` field usage example in `apps/examples`.

For future reference:
The JSON editor widget in `mtable` is improvable via something like that:
https://github.com/josdejong/jsoneditor