### PR TITLE
Tiny fix to make sure __init__.py is present in apps for gae deployment

### DIFF
--- a/deployment_tools/gae/README.md
+++ b/deployment_tools/gae/README.md
@@ -1,10 +1,22 @@
-# to deploy code on Google App Engine:
+# To deploy code on Google App Engine:
 
 ```
 cd deployment_tools/gae
 make setup
 mkdir apps
+touch apps/__init__.py
 # symlink the apps that you want to deploy to GAE, for example:
 ln -s ../../apps/_default apps/_default
+```
+
+Then, you can either do:
+
+```
 make deploy email={your email} project={your project} version={vesion}
+```
+
+or if you have a gcloud configuration already configured, 
+
+```
+gcloud app deploy
 ```


### PR DESCRIPTION
With this fix, deployment on gae works for me. 

One small note: are you sure that symlinks work from the gae/apps directory to ../../apps? 
I thought (I had read in the documentation) that symlinks do not work -- that they are uploaded as symlinks, rather then replicating their target.  I am referring to the line

```
ln -s ../../apps/_default apps/_default
```
in the README. 