### PR TITLE
Fix form handling of readable fields

### DIFF
--- a/py4web/core.py
+++ b/py4web/core.py
@@ -27,7 +27,7 @@ import uuid
 import http.client
 import http.cookies
 import zipfile
-import re 
+import re
 
 REX_APPJSON = re.compile('(^|\s|,)application/json(,|\s|$)')
 
@@ -408,6 +408,12 @@ class Session(Fixture):
     def __setitem__(self, key, value):
         self.local.changed = True
         self.local.data[key] = value
+
+    def keys(self):
+        return self.local.data.keys()
+
+    def __iter__(self):
+        return self.local.data.items()
 
     def on_request(self):
         self.load()
@@ -1059,7 +1065,7 @@ def keyboardInterruptHandler(signal, frame):
     """Catch interrupts like Ctrl-C"""
     print("KeyboardInterrupt (ID: {}) has been caught. Cleaning up...".format(signal))
     sys.exit(0)
-    
+
 def main(args=None):
     """The main entry point: Start the server and create folders"""
     # Store args in the action to make them visible

--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -44,7 +44,7 @@ def FormStyleDefault(table, vars, errors, readonly, deletable, classes=None):
         if field.type == "id" and value is None:
             continue
         if readonly or field.type == "id":
-            control = DIV(field.represent and field.represent(value) or value or "")            
+            control = DIV(field.represent and field.represent(value) or value or "")
         elif field.widget:
             control = field.widget(table, value)
         elif field.type == "text":
@@ -240,7 +240,7 @@ class Form(object):
             if process:
                 if not post_vars.get("_delete"):
                     for field in self.table:
-                        if field.writable:
+                        if field.writable and field.readable:
                             value = post_vars.get(field.name)
                             record_id = self.record and self.record.get("id")
                             (value, error) = field.validate(value, record_id)
@@ -276,6 +276,7 @@ class Form(object):
             self.record.update_record(**self.vars)
         else:
             # warning, should we really insert if record
+            print("Inserting:", self.vars)
             self.vars["id"] = self.table.insert(**self.vars)
 
     def clear(self):

--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -276,7 +276,6 @@ class Form(object):
             self.record.update_record(**self.vars)
         else:
             # warning, should we really insert if record
-            print("Inserting:", self.vars)
             self.vars["id"] = self.table.insert(**self.vars)
 
     def clear(self):


### PR DESCRIPTION
A field should be sent to DAL for writing only if it is writable _and_ readable.  
Otherwise, fields that are writable but not readable will not have their default values set when a record is created. 

Aside from this, the PR adds iterator methods for the session object, so that it becomes possible to write diagnostic code that prints out the code of the session. 
