### PR TITLE
Make apps the default apps_folder

### DIFF
--- a/py4web/core.py
+++ b/py4web/core.py
@@ -944,7 +944,7 @@ def wsgi(**args):
 def get_args():
     """Handle command line arguments"""
     parser = argparse.ArgumentParser()
-    parser.add_argument("-a", "--apps_folder",
+    parser.add_argument("apps_folder",
         nargs = '?',
         default = (os.path.join(os.getcwd(), 'apps')),
         help="Path to the applications folder (default=apps)",

--- a/py4web/core.py
+++ b/py4web/core.py
@@ -16,6 +16,7 @@ import logging
 import numbers
 import os
 import getpass
+import pathlib
 import platform
 import sys
 import threading
@@ -943,10 +944,14 @@ def wsgi(**args):
 
 def get_args():
     """Handle command line arguments"""
+    
+    #get the real running path, needed from MacOs GUI
+    running_path = pathlib.Path(__file__).resolve().parent.parent
+    
     parser = argparse.ArgumentParser()
     parser.add_argument("apps_folder",
         nargs = '?',
-        default = (os.path.join(os.getcwd(), 'apps')),
+        default = (os.path.join(running_path, 'apps')),
         help="Path to the applications folder (default=apps)",
     )
     parser.add_argument(
@@ -996,7 +1001,7 @@ def get_args():
     parser.add_argument(
         "-p",
         "--password_file",
-        default="password.txt",
+        default= (os.path.join(running_path, "password.txt")),
         help="File containing the encrypted (CRYPT) password",
     )
     parser.add_argument(

--- a/py4web/core.py
+++ b/py4web/core.py
@@ -944,7 +944,11 @@ def wsgi(**args):
 def get_args():
     """Handle command line arguments"""
     parser = argparse.ArgumentParser()
-    parser.add_argument("apps_folder", help="Path to the applications folder")
+    parser.add_argument("-a", "--apps_folder",
+        nargs = '?',
+        default = (os.path.join(os.getcwd(), 'apps')),
+        help="Path to the applications folder (default=apps)",
+    )
     parser.add_argument(
         "--host", default="127.0.0.1", help="Server address (IP or hostname)"
     )


### PR DESCRIPTION
This is needed to allow to start the program directly from the GUI - and so it makes py4web much simpler for new users.

After PR web2py#143  was reverted, and the discussion on https://groups.google.com/forum/#!msg/py4web/QKSDCVRX53E/9zMboCJ0BAAJ , this should be fine.