### PR TITLE
Added signature to forms; used hmac

### DIFF
--- a/py4web/utils/url_signer.py
+++ b/py4web/utils/url_signer.py
@@ -1,4 +1,4 @@
-import hashlib
+import hmac
 import uuid
 from py4web import request, abort
 from py4web.core import Fixture, Session
@@ -50,13 +50,13 @@ class URLSigner(object):
         else:
             key = self.session.get("_signature_key")
             if key is None:
-                key = str(uuid.uuid4())
+                key = str(uuid.uuid1())
                 self.session["_signature_key"] = key
         return key
 
     def _sign(self, url, vars):
         """Signs the URL"""
-        h = hashlib.sha256(self.salt)
+        h = hmac.new(self.salt)
         h.update(url.encode('utf8'))  # Is utf8 the right encoding?
         # Adds the variables that need to be signed.
         for key in self.variables_to_sign:


### PR DESCRIPTION
This PR should likely be well reviewed / discussed as it is a bit crucial. 

The PR adds signatures to forms.  To ask for a form to be signed, one adds a csrf_session=session argument to it.  This inserts a _single_ signing key into the session, called _form_key; the same key is used for all forms.  This prevents blowing up the session using one key per form, as was the case in web2py, where the forever-growing session size would eventually blow up sessions stored into cookies. 

Once this is done, a form has: 

* A _formname, used in case more than one form is included in the page. 
* A _formkey, computed by signing some salt.  The salt, and its signature, form the _formkey. 

The _formkey and _formname are verified. 

I also modified the behavior, and if the verification fails, the form now behaves like a GET.  This ensures that, if there are multiple forms on a page, the form whose verification fails (because the post is for the other form) is again re-presented with the data, as if one had requested it fresh. 

I also made both form signatures and URL signatures use hmac. 

**Problem:** If a hmac_session is specified, then we must have @action.uses(session).  I cannot make this form be a Fixture, because this type of forms is created inside a controller, and so, it is not available at the time the @action occurs.  If one forgets the (session) argument, then the key is not saved in the session, and verification typically fails. 

The forms I created for Vue do not have this problem, but I digress. 
