### PR TITLE
Fixed hmac for Python 3.8

### DIFF
--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -1,5 +1,5 @@
 import uuid
-import hmac
+import hashlib, hmac
 from py4web import DAL, request
 from yatl.helpers import (
     A,
@@ -279,21 +279,20 @@ class Form(object):
                 if name in self.record
             }
 
-    def _get_key(self):
+    def _get_signature(self, salt=""):
         key = self.csrf_session.get("_form_key")
         if key is None:
             key = str(uuid.uuid1())
             self.csrf_session["_form_key"] = key
-        return key.encode("utf8")
+        h = hmac.new(key.encode("utf8"), msg=salt.encode("utf8"), digestmod=hashlib.sha256)
+        return h.hexdigest()
 
     def _sign_form(self):
         """Signs the form, for csrf"""
         # Adds a form key.  First get the signing key from the session.
         if self.csrf_session is not None:
             salt = str(uuid.uuid4())
-            h = hmac.new(self._get_key())
-            h.update(salt.encode("utf8"))
-            self.formkey = salt + ";" + h.hexdigest()
+            self.formkey = salt + ";" + self._get_signature(salt)
 
     def _verify_form(self, post_vars):
         """Verifies the csrf signature and form name."""
@@ -304,9 +303,7 @@ class Form(object):
         formkey = post_vars.get("_formkey")
         try:
             salt, u = formkey.split(";")
-            h = hmac.new(self._get_key())
-            h.update(salt.encode("utf8"))
-            return h.hexdigest() == u
+            return u == self._get_signature(salt=salt)
         except:
             return False
 


### PR DESCRIPTION
In Python 3.8, the digetmod= parameter of hmac is compulsory (yes, a compulsory optional parameter apparently). 
I experimented a bit, and even though blake2b is very appealing, the digest size is very long, so I went for sha256 for form and URL signatures.  I still kept the use of the hmac module. 
Sha256 is probably overkill for short-term signatures, but I did not see an obvious reason to go for a shorter one. 

I also refactored a bit the code, to ensure that in url_signer.py and form.py, we create the hmac object in one place only (since it's now more complex to create), to facilitate further changes. 