### PR TITLE
fix to form initialization when form is created as list of Field

### DIFF
--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -273,11 +273,16 @@ class Form(object):
 
     def _read_vars_from_record(self, table):
         if self.record:
-            self.vars = {
-                name: table[name].formatter(self.record[name])
-                for name in table.fields
-                if name in self.record
-            }
+            if isinstance(table, list):
+                # The table is just a list of fields.
+                self.vars = {field.name: self.record.get(field.name)
+                             for field in table}
+            else:
+                self.vars = {
+                    name: table[name].formatter(self.record[name])
+                    for name in table.fields
+                    if name in self.record
+                }
 
     def _get_signature(self, salt=""):
         key = self.csrf_session.get("_form_key")


### PR DESCRIPTION
When a form is defined by a list of Field , rather than an actual table, the initialization of the form values via a record= was broken.  This fixes it.  
One residual problem is that I no longer use: 

```
table[name].formatter(self.record[name])
```
because I don't have a real table; so I just do:
```
field.name: self.record.get(field.name)
```

I hope this works, otherwise feel free to improve. 