### PR TITLE
Updated README to reflect change to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ py4web run apps
 open http://localhost:8000/todo/index
 ```
 
-Notice "py4web-start" uses the pip installed py4web, "./py4web-start.py" uses the local one. Do not get confused.
+Notice "py4web" uses the pip installed py4web, "./py4web.py" uses the local one. Do not get confused.
 Also notice when installing from source the content of py4web/assets is missing and it is created by make assets.
 
 ## Tell me more


### PR DESCRIPTION
With the CLI update the README still refered to "py4web-start" and "./py4web-start.py" instead of "py4web" and "./py4web". This now reflects the py4web update to the CLI.