### PR TITLE
jwt signatures for URLs and forms

### DIFF
--- a/py4web/utils/url_signer.py
+++ b/py4web/utils/url_signer.py
@@ -95,7 +95,7 @@ class URLSigner(Fixture):
             "info": self.signing_info() if self.signing_info is not None else "",
             "vars": {v: repr(variables.get(v)) for v in self.variables_to_sign},
         }
-        key =self._get_key() + "." + json.dumps(additional_key)
+        key = self._get_key() + "." + json.dumps(additional_key)
         print("Key:", key)
         return key
 


### PR DESCRIPTION
This PR adds jwt signatures for URLs and forms, which:

- enables to specify an expiry time
- enables to add user information (not leaked to the token) or other information to the signing key. 

Overall, this is cleaner than the hmac implementation, and more extensible. 

The one point that can be improved is that so far, if a form fails verification, there is no error displayed to the user.  Since the ".accepted" attribute of the form is set to False, the user is simply displayed a new form, as if the user did a GET on the page.  If a form is expired, or fails verification, should a better mechanism be implemented to notify the user that the form submission was rejected? 