### PR TITLE
Implemented functionality to view the entire file in gitlog/Kryten and text updates

### DIFF
--- a/apps/_dashboard/__init__.py
+++ b/apps/_dashboard/__init__.py
@@ -431,9 +431,8 @@ if MODE == "full":
         if not is_git_repo(project):
             raise HTTP(400)
         flag = request.params.get('showfull')
-
+        opt = ""
         if flag == "true":
-            patch = run("git show " + commit + " -U9999", project)
-        else:
-            patch = run("git show " + commit, project)
+            opt = " -U9999"
+        patch = run("git show " + commit + opt, project)
         return diff2kryten(patch)

--- a/apps/_dashboard/__init__.py
+++ b/apps/_dashboard/__init__.py
@@ -288,10 +288,10 @@ if MODE in ("demo", "readonly", "full"):
             }
         elif len(args) > 2 and args[1] in databases:
             db = getattr(module, args[1])
-            id = args[3] if len(args) == 4 else None           
+            id = args[3] if len(args) == 4 else None
             policy = Policy()
             for table in db:
-                policy.set(table._tablename, 'GET', authorize=True, 
+                policy.set(table._tablename, 'GET', authorize=True,
                            allowed_patterns=["**"], allow_lookup=True,
                            fields=table.fields)
                 policy.set(table._tablename,'PUT', authorize=True, fields=table.fields)
@@ -430,5 +430,10 @@ if MODE == "full":
     def gitshow(project, commit):
         if not is_git_repo(project):
             raise HTTP(400)
-        patch = run("git show " + commit, project)
+        flag = request.params.get('showfull')
+
+        if flag == "true":
+            patch = run("git show " + commit + " -U9999", project)
+        else:
+            patch = run("git show " + commit, project)
         return diff2kryten(patch)

--- a/apps/_dashboard/templates/gitlog.html
+++ b/apps/_dashboard/templates/gitlog.html
@@ -1,14 +1,15 @@
 <html>
   <head>
     <base href="[[=URL('static')]]/">
-    <style>      
+    <style>
       * {margin: 0;}
       html {background: white; color: black; font-family: "Courier"; font-size: 10px}}
       a { color: orange; font-weight: bold}
-      td {padding: 5px 10px; color: orange}    
+      td {padding: 5px 10px; color: orange}
+      td.linelength { padding: 5px 10px; color: #f1f1f1; font-weight: bold}
       button.clicked {background: #00d1b2;}
       .commits {
-        position:fixed; top:0; bottom: 0; left:0; z-index:100; 
+        position:fixed; top:0; bottom: 0; left:0; z-index:100;
         width:10px; background: #111111; color: orange; overflow: auto
       }
       .commits:hover { width: 500px; }
@@ -16,9 +17,17 @@
       iframe {width:100%; height:100vh; border:0}
     </style>
   </head>
-  <body>    
+  <body>
     <div class="commits">
       <table>
+        <tr>
+          <td id="result" class="linelength">Show Full File?</td>
+          <td>
+            <input type="checkbox" id="showFull">
+          </td>
+        </tr>
+        <tr height=20px></tr>
+
         [[for commit in commits:]]
         <tr>
           <td>[[=commit.get('message')[:20] ]]</td>
@@ -34,24 +43,64 @@
     </div>
     <div class="kryten">
       Welcome to Kryten!
-      This is an exprimental features of py4web designed for teaching/pesentations.
+      This is an exprimental features of py4web designed for teaching/presentations.
       If you mouseover to the left you will be able to see git commits for the project.
       You will be able to checkout and/or see a commit diff.
       The diff is displayed in an interactive manner.
       Use the following keys to step through a single commit diff:
       <ul>
-        <li>v (%lf;&fl;)</li>
-        <li>b (&lf;)</li>
+        <li>v (&lt;&lt;)</li>
+        <li>b (&lt;)</li>
         <li>n (&gt;)</li>
         <li>m (&gt;&gt;)</li>
       </ul>
-    </div> 
+    </div>
     <script src="js/axios.min.js"></script>
     <script src="js/jquery.min.js"></script>
     <script>
       $('.gitshow').click(function(){
+        checkFull()
         $('.kryten').html('<iframe src="'+$(this).attr('data-src')+'"></iframe>');
       });
+    </script>
+
+
+    <!-- A script to allow for selecting between two attributes based on checkbox -->
+    <script>
+      function checkFull() {
+
+        // Gets the data-src attribute in the gitshow button and the value of the checkbox
+        let str = $( ".gitshow" ).attr( "data-src");
+        let checked = $("#showFull").prop("checked");
+
+        // If we want the full file to be shown
+        // first check if the showfull variable is false and set it to true
+        if(checked) {
+          if(str.includes("?showfull=true")) return;
+          if(str.includes("?showfull=false")) {
+            $( ".gitshow" ).attr( "data-src", str.replace("?showfull=false", "?showfull=true"));
+          }
+        }
+
+
+        // If we DON'T want the full file to be shown
+        // first check if the ?showfull variable is true and set it to false
+        else {
+          if(str.includes("?showfull=false")) return;
+          if(str.includes("?showfull=true")) {
+            $( ".gitshow" ).attr( "data-src", str.replace("?showfull=true", "?showfull=false"));
+          }
+        }
+
+        // If ?showfull isn't in the URL at all, add it based on
+        // the checkbox status
+        if(!str.includes("?showfull=")) {
+            $( ".gitshow" ).attr( "data-src", function( i, val ) {
+              return val + (checked ? "?showfull=true" : "?showfull=false");
+            });
+          }
+          console.log($( ".gitshow" ).attr( "data-src"));
+      }
     </script>
   </body>
 </html>


### PR DESCRIPTION
When using the gitlog feature of the dashboard to view commits, the text output per commit will only show the text around the commit. When building larger applications this becomes a nuisance trying to figure out where exactly you are in the code.

This implements a checkbox in the commits sidebar that allows for the user to select if they want to show the entire file or not. By default, functionality is the same as it was before. However, once the user selects the "Show Full File?" checkbox and clicks "Show" on a commit, when viewing the changes the entire file will be displayed, allowing for better context to where the changes are occurring in the file.

This is accomplished by passing into the git show command the option "-U9999", which, while it is slightly cheating, seems to be the only way to display the entire file through git show.

In addition, a spelling fix in the paragraph about Kryten and changing the code for less than so the symbols next to "v" "b" display as characters.