### PR TITLE
Fix database locked caused by dbstore not committing

### DIFF
--- a/py4web/utils/dbstore.py
+++ b/py4web/utils/dbstore.py
@@ -46,3 +46,4 @@ class DBStore(object):
                 expiration=expiration,
                 ceated_on=None,
             )
+        db.commit()


### PR DESCRIPTION
The database locked problem happens usually after reloading apps in the dashboard.