### PR TITLE
Allowed for more granular syntax highlighting

### DIFF
--- a/apps/_dashboard/diff2kryten.py
+++ b/apps/_dashboard/diff2kryten.py
@@ -21,8 +21,9 @@ html {background-color: white; font-family: helvetica}
 
 script = """
 hljs.initHighlightingOnLoad();
-$('.line:not(.line-new)').each(function(){$(this).text($(this).attr('data-content'));});
+$('.line:not(.line-new)').each(function(){$(this).text($(this).attr('data-content') + "\\n")});
 $('.line-new').hide();
+$('.hide-newline').hide();
 $('.diff').hide();
 $('.file .filename').click(function(){$(this).closest('.file').find('.diff').slideToggle();});
 var block = 0;
@@ -41,28 +42,34 @@ $("html").keypress(function(e){
   if(e.key=="n") {
     $('.line-old[data-block="'+block+'"]').hide();
     $('.line-new[data-block="'+block+'"]').show();
+    $('.hide-newline[data-block="'+block+'"]').show();
     $('.line-new[data-block="'+block+'"]').each(function(){$(this).text($(this).attr('data-content'));});
     if($('.line[data-block="'+(block+1)+'"]').length==0) return;
     block=block+1;
     $('.line-old[data-block="'+block+'"]').hide();
     $('.line-new[data-block="'+block+'"]').show();
+    $('.hide-newline[data-block="'+block+'"]').show();
     $('.line-new[data-block="'+block+'"]').text('');
     $('.line-new[data-block="'+block+'"]').closest('.file').find('.diff').show();
   } else if (e.key=='b') {
     $('.line-old[data-block="'+block+'"]').show();
     $('.line-new[data-block="'+block+'"]').hide();
+    $('.hide-newline[data-block="'+block+'"]').hide();
     block=Math.max(0, block-1);
     $('.line-old[data-block="'+block+'"]').hide();
     $('.line-new[data-block="'+block+'"]').show();
-    $('.line-new[data-block="'+block+'"]').text(function(){$(this).text($(this).attr('data-content'));});
+    $('.hide-newline[data-block="'+block+'"]').show();
+    $('.line-new[data-block="'+block+'"]').text(function(){$(this).text($(this).attr('data-content') );});
     $('.line-new[data-block="'+block+'"]').closest('.file').find('.diff').show();
   } else if (e.key=='v') {
     block=0;
     $('.line-old').show();
+    $('.hide-newline').hide();
     $('.line-new').hide().each(function(){$(this).text('');});
   } else if (e.key=='m') {
     block=%i;
     $('.line-old').hide();
+    $('.hide-newline').show();
     $('.line-new').show().each(function(){$(this).text($(this).attr('data-content'));});
   }
 });
@@ -82,14 +89,15 @@ def escape(txt):
 def getFileType(name):
 
     if name.lower().endswith('py'):
-        return 'class="language-kotlin"'
+        return 'class="language-python"'
     if name.lower().endswith('js'):
-        return 'class="language-coffeescript"'
+        return 'class="language-javascript"'
     if name.lower().endswith('html'):
         return 'class="language-html"'
     if name.lower().endswith('css'):
         return 'class="language-css"'
     return ""
+
 
 
 def diff2kryten(data):
@@ -99,9 +107,9 @@ def diff2kryten(data):
     message = ""
     mode = 0
     block = 0
-    line_old = '<div class="line line-old" data-block="%s" data-content="%s"></div>'
-    line_new = '<div class="line line-new" data-block="%s" data-content="%s"></div>'
-    line_reg = '<div class="line" data-content="%s"></div>'
+    line_old = '<span class="line line-old" data-block="%s" data-content="%s"></span>'
+    line_new = '<span class="line line-new" data-block="%s" data-content="%s"></span><span class="hide-newline" data-block="%s">\n</span>'
+    line_reg = '<span class="line" data-content="%s"></span>'
     for line in lines:
         if line.startswith("---"):
             filename_a = line[4:].strip()
@@ -127,7 +135,7 @@ def diff2kryten(data):
             files[filename]["lines"].append(line_old % (block, escape(line[1:])))
         elif line.startswith("+"):
             mode, block = 3, block + 1
-            files[filename]["lines"].append(line_new % (block, escape(line[1:])))
+            files[filename]["lines"].append(line_new % (block, escape(line[1:]), block))
         elif line.startswith(" ") and mode >= 2:
             files[filename]["lines"].append(line_reg % escape(line[1:]))
             if mode > 2:

--- a/apps/_dashboard/diff2kryten.py
+++ b/apps/_dashboard/diff2kryten.py
@@ -81,13 +81,13 @@ def escape(txt):
 # based on the name of the file
 def getFileType(name):
 
-    if ".py" in name:
+    if name.lower().endswith('py'):
         return 'class="language-kotlin"'
-    if ".js" in name:
+    if name.lower().endswith('js'):
         return 'class="language-coffeescript"'
-    if ".html" in name:
+    if name.lower().endswith('html'):
         return 'class="language-html"'
-    if ".css" in name:
+    if name.lower().endswith('css'):
         return 'class="language-css"'
     return ""
 

--- a/apps/_dashboard/diff2kryten.py
+++ b/apps/_dashboard/diff2kryten.py
@@ -77,6 +77,20 @@ def escape(txt):
         .replace('"', "&quot;")
     )
 
+# specify which language we want to render as for highlight.js
+# based on the name of the file
+def getFileType(name):
+
+    if ".py" in name:
+        return 'class="language-kotlin"'
+    if ".js" in name:
+        return 'class="language-coffeescript"'
+    if ".html" in name:
+        return 'class="language-html"'
+    if ".css" in name:
+        return 'class="language-css"'
+    return ""
+
 
 def diff2kryten(data):
     lines = data.split("\n")
@@ -129,7 +143,7 @@ def diff2kryten(data):
             lines = "".join(files[filename]["lines"])
         div += '<div class="file">'
         div += '<div class="filename">%s (%s)</div>' % (filename, mode)
-        div += '<div class="diff"><pre><code>%s</code></pre></div></div>' % lines
+        div += '<div class="diff"><pre><code %s>%s</code></pre></div></div>' % (getFileType(filename),lines)
     return (
         "<html><head>"
         + '''<link rel="stylesheet"

--- a/apps/_dashboard/templates/gitlog.html
+++ b/apps/_dashboard/templates/gitlog.html
@@ -59,7 +59,7 @@
     <script src="js/jquery.min.js"></script>
     <script>
       $('.gitshow').click(function(){
-        checkFull($(this).attr('id'))
+        checkFull($(this).attr('id'));
         $('.kryten').html('<iframe src="'+$(this).attr('data-src')+'"></iframe>');
       });
     </script>

--- a/apps/_dashboard/templates/gitlog.html
+++ b/apps/_dashboard/templates/gitlog.html
@@ -23,14 +23,14 @@
         <tr>
           <td id="result" class="linelength">Show Full File?</td>
           <td>
-            <input type="checkbox" id="showFull">
+            <input type="checkbox" id="showFull" checked>
           </td>
         </tr>
         <tr height=20px></tr>
 
         [[for commit in commits:]]
         <tr>
-          <td>[[=commit.get('message')[:20] ]]</td>
+          <td>[[=commit.get('message') ]]</td>
           <td>
             [[=checkout.button('Checkout')(project=project, commit=commit['code'])]]
           </td>


### PR DESCRIPTION
Highlight.js will by default try to figure out which file type it is rendering, but sometimes that will have bugs. To make it more granular and specific, a function was added that will set the class of the `<code>` tag to the specific language we need, making sure it will enable the correct highlighting. Because of that, if users want to use gitlog on more file types, to they can just add another case to the function that will correspond to their specific application.

In addition, allowed for more text to be visible in the commit message since it can be difficult to recognize which commit is which with only the first 20 characters.