### PR TITLE
fix memory leaks on reloading

### DIFF
--- a/py4web/core.py
+++ b/py4web/core.py
@@ -826,7 +826,7 @@ class Reloader:
     def clear_routes(app_name=None):
         app = bottle.default_app()
         routes = app.routes[:]
-        app.routes.clear()
+        app.reset() # clear all routes in right way including cached values
         app.router = bottle.Router()
         if app_name:
             for route in routes:
@@ -865,6 +865,8 @@ class Reloader:
                     click.echo("[ ] loading %s ..." % app_name)
                 else:
                     click.echo("[ ] reloading %s ..." % app_name)
+                    if hasattr(module, 'on_unload'):
+                        module.on_unload() # should call db.close() at least
                     # forget the module
                     del Reloader.MODULES[app_name]
                     # all files/submodules

--- a/py4web/core.py
+++ b/py4web/core.py
@@ -826,7 +826,8 @@ class Reloader:
     def clear_routes(app_name=None):
         app = bottle.default_app()
         routes = app.routes[:]
-        app.reset() # clear all routes in right way including cached values
+        app.reset()
+        app.routes.clear()
         app.router = bottle.Router()
         if app_name:
             for route in routes:


### PR DESCRIPTION
- `app.reset()` cleans cache  https://bottlepy.org/docs/dev/api.html#bottle.Bottle.reset
- I found that explicitly invocation `db.close()` before reloading application reduces memory leaks, 
so we need a hook `on_unload` that should be placed in `__init__.py` (if required):
```python
#some_app/__init__.py
...
from .models import db
...
def on_unload():
    db.close()
```
