### PR TITLE
Allow users to select branch in Gitlog

### DIFF
--- a/apps/_dashboard/__init__.py
+++ b/apps/_dashboard/__init__.py
@@ -56,7 +56,7 @@ def get_commits(project):
 
 
 def get_branches(project):
-    """list of git commits for the project"""
+    """dictionary of git local branches for the project"""
     output = run("git branch", project)
     branches = {"current" : "", "other" : []}
     for line in output.split("\n"):

--- a/apps/_dashboard/__init__.py
+++ b/apps/_dashboard/__init__.py
@@ -10,7 +10,7 @@ import datetime
 import requests
 
 import py4web
-from py4web import __version__, action, abort, request, response, redirect, Translator, HTTP
+from py4web import __version__, action, abort, request, response, redirect, Translator, HTTP, URL
 from py4web.core import Reloader, dumps, ErrorStorage, Session, Fixture
 from py4web.utils.factories import ActionFactory
 from pydal.validators import CRYPT
@@ -52,6 +52,19 @@ def get_commits(project):
         else:
             commit["message"] += line.strip() + "\n"
     return commits
+
+
+
+def get_branches(project):
+    """list of git commits for the project"""
+    output = run("git branch", project)
+    branches = {"current" : "", "other" : []}
+    for line in output.split("\n"):
+        if line.startswith("* "):
+            branches["current"] = line[2: ]
+        elif not line == "":
+            branches["other"].append(line[2:])
+    return branches
 
 
 def is_git_repo(project):
@@ -164,7 +177,7 @@ if MODE in ("demo", "readonly", "full"):
             shutil.rmtree(path)
             return {"status": "success", "payload": "Deleted"}
         return {"status": "success", "payload": "App does not exist"}
-    
+
     @action("new_file/<name:re:\w+>/<file_name:path>", method="POST")
     @session_secured
     def new_file(name, file_name):
@@ -187,7 +200,7 @@ if MODE in ("demo", "readonly", "full"):
             elif full_path.endswith(".py"):
                 fp.write('# -*- coding: utf-8 -*-')
         return {"status": "success"}
-    
+
     @action("walk/<path:path>")
     @session_secured
     def walk(path):
@@ -441,9 +454,9 @@ if MODE == "full":
     def gitlog(project):
         if not is_git_repo(project):
             return "Project is not a GIT repo"
-        run("git checkout master", project)
+        branches = get_branches(project)
         commits = get_commits(project)
-        return dict(commits=commits, checkout=checkout, project=project)
+        return dict(commits=commits, checkout=checkout, project=project, branches=branches)
 
     @authenticated.callback()
     def checkout(project, commit):
@@ -452,6 +465,18 @@ if MODE == "full":
         run("git stash", project)
         run("git checkout " + commit, project)
         Reloader.import_app(project)
+
+    @action("swapbranch/<project>/<branch>")
+    @action.uses(Logged(session))
+    def swapbranch(project, branch):
+        if not is_git_repo(project):
+            raise HTTP(400)
+        # swap branches then go back to gitlog so new commits load
+        checkout(project,branch)
+        redirect(URL('gitlog', project))
+        return diff2kryten(patch)
+
+
 
     @action("gitshow/<project>/<commit>")
     @action.uses(Logged(session), "gitshow.html")

--- a/apps/_dashboard/templates/gitlog.html
+++ b/apps/_dashboard/templates/gitlog.html
@@ -5,6 +5,13 @@
       * {margin: 0;}
       html {background: white; color: black; font-family: "Courier"; font-size: 10px}}
       a { color: orange; font-weight: bold}
+      a.button {
+          -webkit-appearance: button;
+          -moz-appearance: button;
+          appearance: button;
+          color: initial;
+          text-decoration: none;
+      }
       td {padding: 5px 10px; color: orange}
       td.linelength { padding: 5px 10px; color: #f1f1f1; font-weight: bold}
       button.clicked {background: #00d1b2;}
@@ -21,9 +28,28 @@
     <div class="commits">
       <table>
         <tr>
-          <td id="result" class="linelength">Show Full File?</td>
+          <td class="linelength">Show Full File?</td>
           <td>
             <input type="checkbox" id="showFull" checked>
+          </td>
+        </tr>
+        <tr>
+          <td class="linelength">Select Branch
+
+          (Currently: [[ =branches.get("current")[:20] ]])
+          </td>
+          <td>
+            <select name="branches" id="branches">
+                    <option value="[[=URL('swapbranch', project, branches.get('current')[:20])]]"> [[ =branches.get("current") ]]</option>
+                    [[for branch in branches.get("other"):]]
+                    <option value="[[=URL('swapbranch', project, branch[:20])]]">[[=branch[:20] ]]</option>
+                    [[pass]]
+              </select>
+          </td>
+          <td>
+            <a class="button" id="swapbranch" href="[[=URL('swapbranch', project, branches.get('current')[:20])]]">
+              Go
+            </a>
           </td>
         </tr>
         <tr height=20px></tr>
@@ -102,5 +128,13 @@
           console.log($( "#" + id ).attr( "data-src"));
       }
     </script>
+    <script>
+       $("#branches").click(function(){
+          var conceptName = $('#branches').val();
+          $("#swapbranch").attr("href", conceptName);
+        });
+    </script>
+
+
   </body>
 </html>


### PR DESCRIPTION
Gitlog on loading will check out the master branch, but if users are working or want to display code that occurs on different branches then there is no way to branch within gitlog. This PR allows for a user to select from a list the branch they want to checkout. This is accomplished by hitting the Go button which will then reload the webpage on the correct branch to grab the commits pertinent to that branch.