### PR TITLE
Cleaned up the branch button on chrome and other attributes for Gitlog

### DIFF
--- a/apps/_dashboard/__init__.py
+++ b/apps/_dashboard/__init__.py
@@ -60,12 +60,6 @@ def get_branches(project):
     output = run("git branch", project)
     branches = {"current" : "", "other" : []}
     for line in output.split("\n"):
-
-        # until able to figure out how to send branches like py4web/test-branch
-        # those branches must be checked out manually through the users git tool
-        # of choice
-        if "/" in line:
-            continue
         if line.startswith("* "):
             branches["current"] = line[2: ]
         elif not line == "":
@@ -472,11 +466,13 @@ if MODE == "full":
         run("git checkout " + commit, project)
         Reloader.import_app(project)
 
-    @action("swapbranch/<project>/<branch>")
+    @action("swapbranch/<project>" , method="POST")
     @action.uses(Logged(session))
-    def swapbranch(project, branch):
+    def swapbranch(project):
         if not is_git_repo(project):
             raise HTTP(400)
+
+        branch = request.forms.get("branches") if request.forms.get("branches") else "master"
         # swap branches then go back to gitlog so new commits load
         checkout(project,branch)
         redirect(URL('gitlog', project))

--- a/apps/_dashboard/__init__.py
+++ b/apps/_dashboard/__init__.py
@@ -60,6 +60,12 @@ def get_branches(project):
     output = run("git branch", project)
     branches = {"current" : "", "other" : []}
     for line in output.split("\n"):
+
+        # until able to figure out how to send branches like py4web/test-branch
+        # those branches must be checked out manually through the users git tool
+        # of choice
+        if "/" in line:
+            continue
         if line.startswith("* "):
             branches["current"] = line[2: ]
         elif not line == "":

--- a/apps/_dashboard/templates/gitlog.html
+++ b/apps/_dashboard/templates/gitlog.html
@@ -9,17 +9,18 @@
           -webkit-appearance: button;
           -moz-appearance: button;
           appearance: button;
-          color: initial;
+          color: white;
           text-decoration: none;
       }
       td {padding: 5px 10px; color: orange}
       td.linelength { padding: 5px 10px; color: #f1f1f1; font-weight: bold}
+      #branch_text {  color: #21aadb; font-weight: bold}
       button.clicked {background: #00d1b2;}
       .commits {
         position:fixed; top:0; bottom: 0; left:0; z-index:100;
-        width:10px; background: #111111; color: orange; overflow: auto
+        width:10px; background: #111111; color: orange; overflow: hidden
       }
-      .commits:hover { width: 500px; }
+      .commits:hover { width: 500px; overflow: auto; }
       .kryten {margin:3%; width:94%; height:94vh; border:0}
       iframe {width:100%; height:100vh; border:0}
     </style>
@@ -28,27 +29,34 @@
     <div class="commits">
       <table>
         <tr>
-          <td class="linelength">Show Full File?</td>
+          <td class="linelength">
+            Show Full File?
+          </td>
           <td>
             <input type="checkbox" id="showFull" checked>
           </td>
         </tr>
         <tr>
-          <td class="linelength">Select Branch
-
-          (Currently: [[ =branches.get("current")[:20] ]])
+          <td class="linelength" id="branch_text">
+            Current Branch: [[ =branches.get("current")[:20] ]]
           </td>
           <td>
             <select name="branches" id="branches">
-                    <option value="[[=URL('swapbranch', project, branches.get('current')[:20])]]"> [[ =branches.get("current") ]]</option>
-                    [[for branch in branches.get("other"):]]
-                    <option value="[[=URL('swapbranch', project, branch[:20])]]">[[=branch[:20] ]]</option>
-                    [[pass]]
+              <option id="[[ =branches.get('current')[:25] ]]" value="[[=URL('swapbranch', project, branches.get('current'))]]">
+                [[ =branches.get("current")[:10] ]]
+              </option>
+
+              [[for branch in branches.get("other"):]]
+              <option id="[[ =branch[:25] ]]" value="[[=URL('swapbranch', project, branch)]]">
+                [[=branch[:10] ]]
+              </option>
+              [[pass]]
               </select>
           </td>
           <td>
-            <a class="button" id="swapbranch" href="[[=URL('swapbranch', project, branches.get('current')[:20])]]">
-              Go
+            <form method="GET" id="swapbranch" action="[[=URL('swapbranch', project, branches.get('current'))]]">
+              <input type="submit" value="Go">
+            </form>
             </a>
           </td>
         </tr>
@@ -56,12 +64,16 @@
 
         [[for commit in commits:]]
         <tr>
-          <td>[[=commit.get('message') ]]</td>
+          <td>
+            [[=commit.get('message')[:60] ]]
+          </td>
           <td>
             [[=checkout.button('Checkout')(project=project, commit=commit['code'])]]
           </td>
           <td>
-            <button class="gitshow" id="[[=commit.get('code')[:20] ]]" data-src="[[=URL('gitshow',project,commit['code'])]]">Show</button>
+            <button class="gitshow" id="[[=commit.get('code')[:20] ]]" data-src="[[=URL('gitshow',project,commit['code'])]]">
+              Show
+            </button>
           <td>
         </tr>
         [[pass]]
@@ -131,7 +143,8 @@
     <script>
        $("#branches").click(function(){
           var conceptName = $('#branches').val();
-          $("#swapbranch").attr("href", conceptName);
+          $('#branch_text').text("Selected Branch: " + $('#branches').children(":selected").attr("id"));
+          $("#swapbranch").attr("action", conceptName);
         });
     </script>
 

--- a/apps/_dashboard/templates/gitlog.html
+++ b/apps/_dashboard/templates/gitlog.html
@@ -5,13 +5,6 @@
       * {margin: 0;}
       html {background: white; color: black; font-family: "Courier"; font-size: 10px}}
       a { color: orange; font-weight: bold}
-      a.button {
-          -webkit-appearance: button;
-          -moz-appearance: button;
-          appearance: button;
-          color: white;
-          text-decoration: none;
-      }
       td {padding: 5px 10px; color: orange}
       td.linelength { padding: 5px 10px; color: #f1f1f1; font-weight: bold}
       #branch_text {  color: #21aadb; font-weight: bold}

--- a/apps/_dashboard/templates/gitlog.html
+++ b/apps/_dashboard/templates/gitlog.html
@@ -20,6 +20,7 @@
   </head>
   <body>
     <div class="commits">
+      <form method="POST" id="my_form" action="[[=URL('swapbranch', project)]]"></form>
       <table>
         <tr>
           <td class="linelength">
@@ -34,23 +35,19 @@
             Current Branch: [[ =branches.get("current")[:20] ]]
           </td>
           <td>
-            <select name="branches" id="branches">
-              <option id="[[ =branches.get('current')[:25] ]]" value="[[=URL('swapbranch', project, branches.get('current'))]]">
-                [[ =branches.get("current")[:10] ]]
-              </option>
-
-              [[for branch in branches.get("other"):]]
-              <option id="[[ =branch[:25] ]]" value="[[=URL('swapbranch', project, branch)]]">
-                [[=branch[:10] ]]
-              </option>
-              [[pass]]
+              <select name="branches" id="branches" form="my_form">
+                <option value="[[=branches.get('current')]]">
+                  [[ =branches.get("current")[:10] ]]
+                </option>
+                [[for branch in branches.get("other"):]]
+                <option value="[[=branch]]">
+                  [[=branch[:10] ]]
+                </option>
+                [[pass]]
               </select>
           </td>
           <td>
-            <form method="GET" id="swapbranch" action="[[=URL('swapbranch', project, branches.get('current'))]]">
-              <input type="submit" value="Go">
-            </form>
-            </a>
+            <input type="submit" value="Go" form="my_form">
           </td>
         </tr>
         <tr height=20px></tr>
@@ -136,8 +133,7 @@
     <script>
        $("#branches").click(function(){
           var conceptName = $('#branches').val();
-          $('#branch_text').text("Selected Branch: " + $('#branches').children(":selected").attr("id"));
-          $("#swapbranch").attr("action", conceptName);
+          $('#branch_text').text("Selected Branch: " + conceptName);
         });
     </script>
 


### PR DESCRIPTION
Using the a tag on chrome even with -webkit-appearance as an attribute would mis-represent the button, so it was better to replace it with a form submit button.

In addition, the line wrapping for too large commit messages and branch names lead to the Checkout and Show buttons extending past the width of the selector panel, so that size was shrunk.

__See below comment for update about dangerous branches after this post__
Finally, there is currently an issue with how the requests to swapping the branch work that if a branch has a / in it (ex: agavgavi-branches/branch-1) the URL will read the slash as a path delimiter. To address this issue for now, all branches with these types of path are not included in the list and users will have to git checkout themselves. However, I am currently working on developing a way to make it such that the branch will be readable in a reasonable manner. However, I personally found that this method would be a good solution for now because the users would not get 404 errors when using the application.