### PR TITLE
add `static_version` option/default setting

### DIFF
--- a/py4web/core.py
+++ b/py4web/core.py
@@ -471,7 +471,7 @@ class Session(Fixture):
 #########################################################################################
 
 
-def URL(*parts, vars=None, hash=None, scheme=False, signer=None, use_appname=True):
+def URL(*parts, vars=None, hash=None, scheme=False, signer=None, use_appname=True, static_version=None):
     """
     Examples:
     URL('a','b',vars=dict(x=1),hash='y')       -> /{script_name?}/{app_name}/a/b?x=1#y
@@ -492,6 +492,13 @@ def URL(*parts, vars=None, hash=None, scheme=False, signer=None, use_appname=Tru
     broken_parts = []
     for part in parts:
         broken_parts += str(part).rstrip("/").split("/")
+    if ( static_version or (use_appname and static_version != "") ) \
+    and broken_parts and broken_parts[0] == 'static':
+        app_module = "apps.%s" % request.app_name
+        static_version = static_version or getattr(sys.modules[app_module], "__static_version__", None)
+        if static_version:
+            broken_parts.insert(1, "_"+static_version)       
+
     url = prefix + "/".join(map(lambda x: urllib.parse.quote(x), broken_parts))
     # Signs the URL if required.  Copy vars into urlvars not to modify it.
     urlvars = {k: v for k, v in vars.items()} if vars else {}

--- a/py4web/core.py
+++ b/py4web/core.py
@@ -492,10 +492,14 @@ def URL(*parts, vars=None, hash=None, scheme=False, signer=None, use_appname=Tru
     broken_parts = []
     for part in parts:
         broken_parts += str(part).rstrip("/").split("/")
-    if ( static_version or (use_appname and static_version != "") ) \
-    and broken_parts and broken_parts[0] == 'static':
-        app_module = "apps.%s" % request.app_name
-        static_version = static_version or getattr(sys.modules[app_module], "__static_version__", None)
+    if static_version != "" and broken_parts and broken_parts[0] == 'static':
+        if not static_version: # try to retrieve from __init__.py
+            app_module = (
+                "apps.%s" % request.app_name 
+                if use_appname
+                else "apps"
+            )
+            static_version = getattr(sys.modules[app_module], "__static_version__", None)
         if static_version:
             broken_parts.insert(1, "_"+static_version)       
 

--- a/py4web/core.py
+++ b/py4web/core.py
@@ -501,7 +501,7 @@ def URL(*parts, vars=None, hash=None, scheme=False, signer=None, use_appname=Tru
             )
             static_version = getattr(sys.modules[app_module], "__static_version__", None)
         if static_version:
-            broken_parts.insert(1, "_"+static_version)       
+            broken_parts.insert(1, "_"+static_version)
 
     url = prefix + "/".join(map(lambda x: urllib.parse.quote(x), broken_parts))
     # Signs the URL if required.  Copy vars into urlvars not to modify it.


### PR DESCRIPTION
To set  `static_version` for whole app:
```python
#apps/__init__.py
...
__static_version__ = "0.0.1"  
...
#-------------
#some_app/__init__.py
...
__static_version__ = "0.0.2"  
...
#-------------

# examples:
# URL('static', 'vue.js') == 'some_app/static/_0.0.2/vue.js'
# URL('static', 'vue.js', static_version = '') == 'some_app/static/vue.js'
# URL('static', 'vue.js', static_version = '0.0.3') == 'some_app/static/_0.0.3/vue.js'
# URL('static', 'vue.js', use_appname = False) == '/static/_0.0.1/vue.js'
# URL('static', 'vue.js', use_appname = False, static_version = '') == '/static/vue.js'
...
```