### PR TITLE
README update to new cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ py4web run -H 127.0.0.1 -P 8000 -d demo apps
 
 Note:
 
-By default the host will be set to localhost or 127.0.0.1 and the port will be 8000. So the command above can be shortened to:
+By default the host will be set to 127.0.0.1 (localhost) and the port will be 8000. So the command above can be shortened to:
 
 ```
 py4web run -d demo apps

--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ Usage: py4web.py run [OPTIONS] [APPS_FOLDER]
 
 Options:
   -Y, --yes                     No prompt, assume yes to questions
-  -H, --host TEXT               Host name
-  -P, --port INTEGER            Port number
+  -H, --host TEXT               Host name (default 127.0.0.1)
+  -P, --port INTEGER            Port number (default 8000)
   -p, --password_file TEXT      File for the encrypted password
   -w, --number_workers INTEGER  Number of workers
   -d, --dashboard_mode TEXT     Dashboard mode: demo, readonly, full
@@ -128,9 +128,7 @@ Example:
 py4web run -H 127.0.0.1 -P 8000 -d demo apps
 ```
 
-Note:
-
-By default the host will be set to 127.0.0.1 (localhost) and the port will be 8000. So the command above can be shortened to:
+Note that since the default (as specified above) for the host and port are 127.0.0.1 and 8000 respectively, the above command can be shortened to:
 
 ```
 py4web run -d demo apps

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ open http://localhost:8000/todo/index
 
 ```
 git clone https://github.com/web2py/py4web.git
-cd py4web 
+cd py4web
 python3 -m pip install -r requirements.txt
 ./py4web.py setup apps
 ./py4web.py set-password
@@ -84,10 +84,10 @@ Also notice when installing from source the content of py4web/assets is missing 
 - gunicorn (done)
 - bottle (done)
 
-## Storing _dashboard password 
+## Storing _dashboard password
 
-When py4web starts it asks for a _dashboard password and stores its pdkdf2 hash 
-in password.txt, in the working folder. It will not ask again unless the file is deleted. 
+When py4web starts it asks for a _dashboard password and stores its pdkdf2 hash
+in password.txt, in the working folder. It will not ask again unless the file is deleted.
 If the ``--dashboard_mode`` is ``demo`` or ``none`` it will not ask.
 If you want to store it somewhere else, you can specify a name with ``--password_file``.
 
@@ -101,41 +101,39 @@ password: *****
 ## Launch Arguments
 
 ```
-usage: py4web-start.py [-h] [--host HOSTNAME] [--port PORT] [--headless] [-n NUMBER_WORKERS]
-                       [--ssl_cert_filename SSL_CERT_FILENAME]
-                       [--ssl_key_filename SSL_KEY_FILENAME]
-                       [--service_db_uri SERVICE_DB_URI] [-d DASHBOARD_MODE]
-                       [-p PASSWORD_FILE] [-c]
-                       apps_folder
+Usage: py4web.py run [OPTIONS] [APPS_FOLDER]
 
-positional arguments:
-  apps_folder           path to the applications folder
+Options:
+  -Y, --yes                     No prompt, assume yes to questions
+  -H, --host TEXT               Host name
+  -P, --port INTEGER            Port number
+  -p, --password_file TEXT      File for the encrypted password
+  -w, --number_workers INTEGER  Number of workers
+  -d, --dashboard_mode TEXT     Dashboard mode: demo, readonly, full
+                                (default), none
 
-optional arguments:
-  -h, --help            show this help message and exit
-  --host HOSTNAME       server address (IP or hostname)
-  --port PORT           server port number (e.g., 8000)
-  --headless            hide artwork for console based servers
-  -n NUMBER_WORKERS, --number_workers NUMBER_WORKERS
-                        number of gunicorn workers
-  --ssl_cert_filename SSL_CERT_FILENAME
-                        ssl certificate file
-  --ssl_key_filename SSL_KEY_FILENAME
-                        ssl key file
-  --service_db_uri SERVICE_DB_URI
-                        db uri for logging
-  -d DASHBOARD_MODE, --dashboard_mode DASHBOARD_MODE
-                        dashboard mode: demo, readonly, full (default), none
-  -p PASSWORD_FILE, --password_file PASSWORD_FILE
-                        file containing the encrypted (CRYPT) password
-  -c, --create          created the missing folder and apps
+  --watch [off|sync|lazy]       Watch python changes and reload apps
+                                automatically, modes: off (default), sync,
+                                lazy
+
+  --ssl_cert TEXT               SSL certificate file for HTTPS
+  --ssl_key TEXT                SSL key file for HTTPS
+  --help                        Show this message and exit.
 ```
 
 Example:
 
 
 ```
-py4web-start -a 127.0.0.1:8000 -d demo apps
+py4web run -H 127.0.0.1 -P 8000 -d demo apps
+```
+
+Note:
+
+By default the host will be set to localhost or 127.0.0.1 and the port will be 8000. So the command above can be shortened to:
+
+```
+py4web run -d demo apps
 ```
 
 ## WSGI

--- a/py4web/core.py
+++ b/py4web/core.py
@@ -1035,7 +1035,6 @@ def start_server(args):
 
     server = None # need for watcher
     run = lambda: 0 # main run
-
     if platform.system().lower() == "windows":
         # Tornado fail on windows
         server = 'default'
@@ -1058,8 +1057,8 @@ def start_server(args):
                 workers=number_workers,
                 worker_class="gevent",
                 reloader=False,
-                certfile=args.ssl_cert_filename,
-                keyfile=args.ssl_key_filename,
+                certfile=args['ssl_cert'],
+                keyfile=args['ssl_key'],
             )
 
     if args['watch'] != 'off':

--- a/py4web/core.py
+++ b/py4web/core.py
@@ -495,7 +495,7 @@ def URL(*parts, vars=None, hash=None, scheme=False, signer=None, use_appname=Tru
     if static_version != "" and broken_parts and broken_parts[0] == 'static':
         if not static_version: # try to retrieve from __init__.py
             app_module = (
-                "apps.%s" % request.app_name 
+                "apps.%s" % request.app_name
                 if use_appname
                 else "apps"
             )
@@ -1200,8 +1200,8 @@ def set_password(password, password_file):
 @cli.command()
 @click.argument('apps_folder', default='apps')
 @click.option('-Y', '--yes', is_flag=True, default=False, help='No prompt, assume yes to questions')
-@click.option('-H', '--host', default='127.0.0.1', help='Host name')
-@click.option('-P', '--port', default=8000, type=int, help='Port number')
+@click.option('-H', '--host', default='127.0.0.1', help='Host name (default 127.0.0.1)')
+@click.option('-P', '--port', default=8000, type=int, help='Port number (default 8000)')
 @click.option('-p', '--password_file', default='password.txt', help='File for the encrypted password')
 @click.option('-w', '--number_workers', default=0, type=int, help='Number of workers')
 @click.option('-d', '--dashboard_mode',  default='full', help='Dashboard mode: demo, readonly, full (default), none')


### PR DESCRIPTION
The Launch Argument section of README.md has now been updated to the new CLI. This accounts for the changes in areas such as the renaming of `--ssl_cert_filename` to `--ssl_cert` and the removal of `--service_db_uri` and `--headless` which wouldn't be known otherwise without digging into the code.

It also updates the example below launch argument to account for this change while discussing the default values of `--host` and `--port`

In addition, with the renaming of `--ssl_whatever`, the `start_server` function would error if the number of workers was ever greater than 0 since it relied on `ssl_whatever_filename` instead of `ssl_whatever`.