### PR TITLE
fix error: "id" violates not-null constraint  in utils.form

### DIFF
--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -75,6 +75,7 @@ class FormStyleFactory:
             if field.type == "blob":  # never display blobs (mistake?)
                 continue
             if field.type == "id" and value is None:
+                field.writable = False
                 continue
             if readonly or field.type == "id":
                 control = DIV(field.represent and field.represent(value) or value or "")


### PR DESCRIPTION
error found when connected to a postgresql database.
ref: #223 psycopg2.errors.NotNullViolation: null value in column "id" violates not-null constraint 