### PR TITLE
add labels dict to field form controls

### DIFF
--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -63,6 +63,7 @@ class FormStyleFactory:
             _method="POST", _action=request.url, _enctype="multipart/form-data"
         )
         controls = dict(
+            labels=dict(),
             widgets=dict(),
             hidden_widgets=dict(),
             errors=dict(),
@@ -154,6 +155,7 @@ class FormStyleFactory:
                 key += "[type=%s]" % (control["_type"] or "text")
             control["_class"] = self.classes.get(key, "")
 
+            controls["labels"][field.name] = field.label
             controls["widgets"][field.name] = control
             if error:
                 controls["errors"][field.name] = error


### PR DESCRIPTION
Add a [labels] dict to the controls variable in FormStyleFactory.produce().  This is to provide functionality similar to web2py for custom forms and displaying the label defined when using Form with a field list (Similar to SQLFORM.factory() in web2py).  Now in a custom form in html I can:

[[=form.custom['begin'] ]]
<div>
[[=form.custom['labels']['field_name'] ]]
</div>
<div>
[[=form.custom['widgets']['field_name'] ]]
</div>

Prior to this change you could not use the 'labels' dict to get the label from the field when using custom forms.