### PR TITLE
Make field 'comments' available to custom forms

### DIFF
--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -65,6 +65,7 @@ class FormStyleFactory:
         controls = dict(
             labels=dict(),
             widgets=dict(),
+            comments=dict(),
             hidden_widgets=dict(),
             errors=dict(),
             begin=XML(form.xml().split("</form>")[0]),
@@ -157,6 +158,7 @@ class FormStyleFactory:
 
             controls["labels"][field.name] = field.label
             controls["widgets"][field.name] = control
+            controls["comments"][field.name] = field.comment if field.comment else ''
             if error:
                 controls["errors"][field.name] = error
 


### PR DESCRIPTION
Same as adding the label attribute, this change pulls the comments attribute of a Field into the control and makes it available to custom forms.  I sometimes like to use this as a little helper for the user on what the field is for.