### PR TITLE
Render hidden widgets for custom forms

### DIFF
--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -442,7 +442,12 @@ class Form(object):
                     _type="hidden", _name=key, _value=self.hidden[key]
                 )
                 helper["form"].append(helper["controls"]["hidden_widgets"][key])
+
+            helper["controls"]["begin"] = XML(''.join(str(helper["controls"]["begin"]) +
+                                      str(helper["controls"]["hidden_widgets"][hidden_field])
+                                      for hidden_field in helper["controls"]["hidden_widgets"]))
             self.cached_helper = helper
+
         return self.cached_helper
 
     @property


### PR DESCRIPTION
Automatically render hidden_widgets for custom forms.  If I use [[=form]] in my template the hidden_widgets are rendered onto the page.  If I use [[=form.custom["being"] ]] then I need to render them manually.  This change renders the hidden_widgets automatically for custom forms.  I added the hidden widgets to the beginning of the form.  If preferred, I can change this to add them to the end of the form.