### PR TITLE
Bugfix Oauth statechecker

### DIFF
--- a/py4web/utils/auth_plugins/__init__.py
+++ b/py4web/utils/auth_plugins/__init__.py
@@ -122,6 +122,8 @@ class OAuth2(SSO):
         )
         scope = self.parameters.get("scope")
         state = self.state_generator()
+        global passedstate
+        passedstate=state
         if scope:
             data["scope"] = scope
             data["include_granted_scopes"] = "true"


### PR DESCRIPTION
Fix bug always returning "401 not authorized" when using Oauth, because passedstate variable was never defined. Sorry, I did not merge my code corretly before. Just went through a whole other test cycle and now it all works as expected and as it was in my orginial development code. Next time I will directly merge the code from my development environment in order to avoid any "code replication" errors, by missing to add some of the changes into the git commit that I did in  my development environment.