### PR TITLE
Adjusted Fontawesome 5 to CSS over JS due to SVG issues with icons.

### DIFF
--- a/apps/examples/static/components/starrater/starrater.html
+++ b/apps/examples/static/components/starrater/starrater.html
@@ -2,7 +2,7 @@
     <span v-on:mouseover="stars_over(idx)"
           v-on:click="set_stars(idx)"
           v-for="idx in star_indices">
-        <i v-if="idx <= num_stars_display" class="fa fa-star"></i>
-        <i v-if="idx > num_stars_display" class="fa fa-star-o"></i>
+        <i v-if="idx <= num_stars_display" class="fas fa-star"></i>
+        <i v-if="idx > num_stars_display" class="far fa-star"></i>
     </span>
 </span>

--- a/apps/examples/templates/layout.html
+++ b/apps/examples/templates/layout.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="data:image/x-icon;base64,AAABAAEAAQEAAAEAIAAwAAAAFgAAACgAAAABAAAAAgAAAAEAIAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAPAAAAAA=="/>
     <link rel="stylesheet" href="css/no.css">
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.10.0/css/all.css"/>
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css"/>
     <style>.help{margin-top:-16px; font-size:0.8em;} .is-danger{color:red}</style>
     [[block page_head]]<!-- individual pages can customize header here -->[[end]]
   </head>

--- a/apps/examples/templates/layout.html
+++ b/apps/examples/templates/layout.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="data:image/x-icon;base64,AAABAAEAAQEAAAEAIAAwAAAAFgAAACgAAAABAAAAAgAAAAEAIAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAPAAAAAA=="/>
     <link rel="stylesheet" href="css/no.css">
-    <link rel="stylesheet" href="https://pro.fontawesome.com/releases/v5.10.0/css/all.css"/>
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.10.0/css/all.css"/>
     <style>.help{margin-top:-16px; font-size:0.8em;} .is-danger{color:red}</style>
     [[block page_head]]<!-- individual pages can customize header here -->[[end]]
   </head>

--- a/apps/examples/templates/layout.html
+++ b/apps/examples/templates/layout.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="data:image/x-icon;base64,AAABAAEAAQEAAAEAIAAwAAAAFgAAACgAAAABAAAAAgAAAAEAIAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAPAAAAAA=="/>
     <link rel="stylesheet" href="css/no.css">
-    <script defer src="https://use.fontawesome.com/releases/v5.3.1/js/all.js"></script>
+    <link rel="stylesheet" href="https://pro.fontawesome.com/releases/v5.10.0/css/all.css"/>
     <style>.help{margin-top:-16px; font-size:0.8em;} .is-danger{color:red}</style>
     [[block page_head]]<!-- individual pages can customize header here -->[[end]]
   </head>


### PR DESCRIPTION
With Fontawesome 5, icons have translated over to SVG and are unwrapped in the DOM when using the `.js` version currently in `layout.html`. This leads to some issues updating classes with Vue, you can no longer follow the same methodology as before. This led to Luca's Starrater component to break in multiple ways.

Currently the best was I've found is to use the WebCSS version of fontawesome instead of the SVG/JS version which works, but if any example apps require the version Massimo already has in `layout.html` when he updated to Font Awesome 5, this would not work.

Another solution would be to instead of automatically including font-awesome in `layout.html`, that would be delegated to a developer inserting it into the `block page_head`. That way developers could select between if they want CSS or JS.

Since @lucadealfaro is the creator of these components, he may have a better solution in mind, but this is just an attempt to fix it and get it to work in the current version of py4web.