### PR TITLE
Make _title and _placeholder available to fields

### DIFF
--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -66,6 +66,8 @@ class FormStyleFactory:
             widgets=dict(),
             comments=dict(),
             hidden_widgets=dict(),
+            placeholders=dict(),
+            titles=dict(),
             errors=dict(),
             begin=XML(form.xml().split("</form>")[0]),
             end=XML("</form>"),
@@ -82,6 +84,8 @@ class FormStyleFactory:
             value = vars.get(field.name, field.default)
             error = errors.get(field.name)
             field_class = field.type.split()[0].replace(":", "-")
+            placeholder = field._placeholder if '_placeholder' in field.__dict__ else None
+            title = field._title if '_title' in field.__dict__ else None
 
             if not field.readable and not field.writable:
                 continue
@@ -97,20 +101,24 @@ class FormStyleFactory:
             elif field.widget:
                 control = field.widget(table, value)
             elif field.type == "text":
-                control = TEXTAREA(value or "", _id=input_id, _name=field.name)
+                control = TEXTAREA(value or "", _id=input_id, _name=field.name,
+                                  _placeholder=placeholder, _title=title)
             elif field.type == "date":
                 control = INPUT(
-                    _value=value, _type="date", _id=input_id, _name=field.name
+                    _value=value, _type="date", _id=input_id, _name=field.name,
+                    _placeholder=placeholder, _title=title
                 )
             elif field.type == "datetime":
                 if isinstance(value, str):
                     value = value.replace(" ", "T")
                 control = INPUT(
-                    _value=value, _type="datetime-local", _id=input_id, _name=field.name
+                    _value=value, _type="datetime-local", _id=input_id, _name=field.name,
+                    _placeholder=placeholder, _title=title
                 )
             elif field.type == "time":
                 control = INPUT(
-                    _value=value, _type="time", _id=input_id, _name=field.name
+                    _value=value, _type="time", _id=input_id, _name=field.name,
+                    _placeholder=placeholder, _title=title
                 )
             elif field.type == "boolean":
                 control = INPUT(
@@ -119,6 +127,7 @@ class FormStyleFactory:
                     _name=field.name,
                     _value="ON",
                     _checked=value,
+                    _title=title,
                 )
             elif field.type == "upload":
                 control = DIV(INPUT(_type="file", _id=input_id, _name=field.name))
@@ -126,7 +135,8 @@ class FormStyleFactory:
                     control.append(A("download", _href=field.download_url(value)))
                     control.append(
                         INPUT(
-                            _type="checkbox", _value="ON", _name="_delete_" + field.name
+                            _type="checkbox", _value="ON", _name="_delete_" + field.name,
+                            _title=title
                         )
                     )
                     control.append("(check to remove)")
@@ -138,7 +148,8 @@ class FormStyleFactory:
                     for k, v in get_options(field.requires)
                 ]
                 control = SELECT(
-                    *option_tags, _id=input_id, _name=field.name, _multiple=multiple
+                    *option_tags, _id=input_id, _name=field.name, _multiple=multiple, 
+                    _title=title
                 )
             else:
                 field_type = "password" if field.type == "password" else "text"
@@ -148,6 +159,8 @@ class FormStyleFactory:
                     _name=field.name,
                     _value=value,
                     _class=field_class,
+                    _placeholder=placeholder,
+                    _title=title
                 )
 
             key = control.name.rstrip("/")
@@ -157,7 +170,9 @@ class FormStyleFactory:
 
             controls["labels"][field.name] = field.label
             controls["widgets"][field.name] = control
-            controls["comments"][field.name] = field.comment if field.comment else ''
+            controls["comments"][field.name] = field.comment if field.comment else ""
+            controls["titles"][field.name] = title
+            controls["placeholders"][field.name] = placeholder
             if error:
                 controls["errors"][field.name] = error
 


### PR DESCRIPTION
I would like the ability to pass title and placeholder to fields.  This update allows that.  

Use case:

form = Form([Field('name', length=50, _placeholder='Please Enter your Name'), Field('email', length=100, _placeholder='Email', _title='This is needed for communications')])

Now when I build my form, the placeholders and titles will be there for me to access if I want to display them.

I'll understand if you don't see the need.  I feel it would be helpful.