### PR TITLE
ThreadSafe pydal patch

### DIFF
--- a/py4web/core.py
+++ b/py4web/core.py
@@ -289,9 +289,10 @@ class DAL(pydal.DAL, Fixture):
 
 # make sure some variables in pydal are thread safe
 def thread_safe_pydal_patch():
+    Field = pydal.DAL.Field
     tsafe_attrs = ["readable", "writable", "default", "update", "requires"]
     for a in tsafe_attrs:
-        setattr(pydal.DAL.Field, a, threadsafevariable.ThreadSafeVariable())
+        setattr(Field, a, threadsafevariable.ThreadSafeVariable())
 
     # hack "copy.copy" behavior, since it makes a shallow copy,
     # but ThreadSafe-attributes (see above) are class-level, so:
@@ -306,7 +307,11 @@ def thread_safe_pydal_patch():
         for a in tsafe_attrs:
             setattr(clone, a, getattr(self, a))
         return clone
-    setattr(Field, '__copy__',field_copy)
+
+    # to avoid possible future problems
+    if Field.__copy__:
+        raise RuntimeError("code fix required!")
+    setattr(Field, '__copy__', field_copy)
 thread_safe_pydal_patch()
 
 # this global object will be used to store their state to restore it for every http request

--- a/py4web/core.py
+++ b/py4web/core.py
@@ -309,7 +309,7 @@ def thread_safe_pydal_patch():
         return clone
 
     # to avoid possible future problems
-    if Field.__copy__:
+    if hasattr(Field, "__copy__"):
         raise RuntimeError("code fix required!")
     setattr(Field, '__copy__', field_copy)
 thread_safe_pydal_patch()


### PR DESCRIPTION
There is a bug in case of usage [Table-inheritance](http://www.web2py.com/books/default/chapter/29/06/the-database-abstraction-layer#Table-inheritance)
The reason:
"copy.copy" makes a shallow copy,
but Field ThreadSafe-attributes ("readable", "writable", "default", "update", "requires") are class-level as they are [patched](https://github.com/web2py/py4web/blob/2865f3929ab1dd837d3f8566d6a9a3d6621c9c0e/py4web/core.py#L289-L292) by py4web , so:
no copy -> no attr in ICECUBE for the fresh one -> gevent-error on try to access to any of ThreadSafe-attributes
