### PR TITLE
Fix set-password in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ git clone https://github.com/web2py/py4web.git
 cd py4web
 python3 -m pip install -r requirements.txt
 ./py4web.py setup apps
-./py4web.py set_password
+./py4web.py set-password
 ./py4web.py run apps
 open http://localhost:8000/todo/index
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ```
 python3 -m pip install -U py4web --no-cache-dir --user
 py4web setup apps
-py4web set_password
+py4web set-password
 py4web run apps
 open http://localhost:8000/todo/index
 ```


### PR DESCRIPTION
README.md file has a small typo error :  

     py4web set_password 

instead of 

     py4web set-password 

this pull request fix both