### PR TITLE
fix auth/api

### DIFF
--- a/py4web/utils/auth.py
+++ b/py4web/utils/auth.py
@@ -406,10 +406,13 @@ class Auth(Fixture):
 
             @mount('POST')
             def login(vars, *a, **v):
+                username, password = vars.get("email"), vars.get("password")
+                if not all(isinstance(_, str) for _ in [username, password]):
+                    return self._error("Invalid Credentials")
+
                 # Prioritize PAM or LDAP logins if enabled
                 if "pam" in self.plugins or "ldap" in self.plugins:
                     plugin_name = "pam" if "pam" in self.plugins else "ldap"
-                    username, password = vars.get("email"), vars.get("password")
                     check = self.plugins[plugin_name].check_credentials(
                         username, password
                     )
@@ -428,7 +431,7 @@ class Auth(Fixture):
                         data = self._error("Invalid Credentials")
                 # Else use normal login
                 else:
-                    user, error = self.login(**vars)
+                    user, error = self.login(username, password)
                     if user:
                         self.session["user"] = {"id": user.id}
                         self.session["recent_activity"] = calendar.timegm(

--- a/py4web/utils/auth.py
+++ b/py4web/utils/auth.py
@@ -459,7 +459,7 @@ class Auth(Fixture):
 
             @mount('POST', user= 'public')
             def logout(user, *a, **v):
-                self.session["user"] = None
+                self.session.clear()
 
             @mount('POST', user= 'private')
             def unsubscribe(user, *a, **v):
@@ -521,7 +521,7 @@ class Auth(Fixture):
             return data
         # logout/
         elif path == "logout":
-            self.session.clear() # why in case of api/logout: self.session["user"] = None?
+            self.session.clear()
             # Somehow call revoke for active plugin
         # verify_email/
         elif path == "verify_email" and self.db:


### PR DESCRIPTION
I met a bug  - `GET auth/api/logout` - returns success, but nothing is performed (user is still in session). I suppose this is not the only bug like this,  because there is not path-method validation. Therefor I rewrote auth/api in more reliable/readable style. Now, all api-handlers in the `auth.api` that is dict like `{'profile': {'GET': get_profile_handler, 'POST':  post_profile_handler,}, ...}` which is generated by `auth.make_api()` at `auth.__init__()`.
Also, I have some questions about login/logout logic  - see comments in code.
And one more note about logic:
As I see, in case of any errors api returns code 200 with actual code and error-message in the response. As for me (given that this is **api**) it is overhead and not convenient. I think api should response with actual code and processed in this common way:
```javascript
        axios.post('../auth/api/register', form)
            .then(function(res){self.go('registered')})
            .catch(function(err){
                var res = err.response;
                if(res.data.errors) self.errors = res.data.errors;
                else alert(res.data.message);
            });
```
instead of:
https://github.com/web2py/py4web/blob/75cbe6229e8530d578c41da45c009580dc6da86f/apps/_scaffold/static/components/auth.js#L69-L73