### PR TITLE
Updated flash in _scaffold to standard and updated unauthenticated

### DIFF
--- a/apps/_scaffold/controllers.py
+++ b/apps/_scaffold/controllers.py
@@ -27,13 +27,12 @@ Warning: Fixtures MUST be declared with @action.uses({fixtures}) else your app w
 
 from py4web import action, request, abort, redirect, URL
 from yatl.helpers import A
-from .common import db, session, T, cache, auth, logger, authenticated, unauthenticated
+from .common import db, session, T, cache, auth, logger, authenticated, unauthenticated, flash
 
 
-@unauthenticated()
-@action("index")
-@action.uses(auth, "index.html")
+@unauthenticated("index", "index.html")
 def index():
     user = auth.get_user()
+    flash.set("Hello world")
     message = T("Hello {first_name}".format(**user) if user else "Hello")
-    return dict(message=message, flash="Hello world")
+    return dict(message=message)


### PR DESCRIPTION
Fixed the use of `flash='Hello world'` in the `_scaffold` controller to `flash.set('Hello world')`

In addition, since it discusses that `@unauthenticated` and `@action` shouldn't be combined in the documentation [here ](https://github.com/web2py/py4web/blob/32b87a247a3e3823a0e6038d6b2b3e46be98890b/apps/_documentation/static/chapters/en/chapter-04.mm#L50), replaced `@action` and `@action.uses` with the simplified `@unauthenticated`