### PR TITLE
Fix errors on py4web startup for missing '_scaffold/databases' folder

### DIFF
--- a/apps/_scaffold/databases/README.md
+++ b/apps/_scaffold/databases/README.md
@@ -1,0 +1,2 @@
+
+This is just a placeholder for the needed '_scaffold/databases' folder


### PR DESCRIPTION
That folder is needed ...