### PR TITLE
Use Colorama module for ANSI printout

### DIFF
--- a/py4web/core.py
+++ b/py4web/core.py
@@ -1023,15 +1023,15 @@ class Reloader:
                 module = importlib.machinery.SourceFileLoader(
                     module_name, init
                 ).load_module()
-                click.echo("\x1b[A[X] loaded %s       " % app_name, color="green")
+                click.secho("\x1b[A[X] loaded %s       " % app_name, fg="green")
                 Reloader.MODULES[app_name] = module
                 Reloader.ERRORS[app_name] = None
             except:
                 tb = traceback.format_exc()
                 print(tb)
-                click.echo(
+                click.secho(
                     "\x1b[A[FAILED] loading %s       \n%s\n" % (app_name, tb),
-                    color="red",
+                    fg="red",
                 )
                 Reloader.ERRORS[app_name] = tb
                 # clear all files/submodules if the loading fails
@@ -1329,13 +1329,6 @@ def wsgi(**args):
 #########################################################################################
 
 
-def fix_ansi_on_windows():
-    if platform.system().lower() == "windows":  # fix for ANSI on Win7, 8, 10 ...
-        from ctypes import windll
-
-        windll.kernel32.SetConsoleMode(windll.kernel32.GetStdHandle(-11), 7)
-
-
 def keyboardInterruptHandler(signal, frame):
     """Catch interrupts like Ctrl-C"""
     click.echo(
@@ -1390,7 +1383,6 @@ def setup(**args):
 def shell(apps_folder):
     """Open a python shell with apps_folder added to the path"""
     install_args(dict(apps_folder=apps_folder))
-    fix_ansi_on_windows()
     code.interact(local=dict(globals(), **locals()))
 
 
@@ -1491,7 +1483,7 @@ def run(**args):
 
     from py4web import __version__
 
-    click.echo(ART, color="blue")
+    click.secho(ART, fg="blue")
     click.echo("Py4web: %s on Python %s\n\n" % (__version__, sys.version))
 
     # If we know where the password is stored, read it, otherwise ask for one

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 bottle >= 0.12
 click
+colorama
 tornado
 gunicorn
 gevent<=1.4.0


### PR DESCRIPTION
The colorama module is automatically used by Click if present. This is highly compatible (especially for Windows that otherwise has many problems with ANSI) and now we can simply and effectively use colors! Tested with Win , Mac, Linux + python 3.7 and 3.8