### PR TITLE
Add search_queries implementation

### DIFF
--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -303,7 +303,7 @@ def FormStyleBulma(table, vars, errors, readonly, deletable):
         "input[type=radio]": "radio",
         "input[type=checkbox]": "checkbox",
         "input[type=submit]": "button",
-        "input[type=password]": "password",
+        "input[type=password]": "input password",
         "input[type=file]": "file",
         "select": "control select",
         "textarea": "textarea",


### PR DESCRIPTION
Added search_queries implementation per Massimo's suggestion.  Example

search_queries = [['Search by Number', lambda value: db.region.region_number == value],
                              ['Search by id', lambda value: db.region.id == value]]

I think it would also be nice to be able to add a requires to the fields as I create them.  Do you think it would make sense to convert this list of lists to search_query objects or just add another positional value after the query where you you could put a dal requires?

```
search_queries = [search_query('Search by Number', 
                               query=lambda value: db.region.region_number == value, 
                               requires=dal_requires_for_region_number),
                  search_query('Search by id', 
                               query=lambda: db.region.id == value,
                               requires=dal_requires_for_id)
```
or

```
search_queries = [['Search by Number', lambda value: db.region.region_number == value, dal_requires_for_region_number],
                  ['Search by id', lambda value: db.region.id == value, dal_requires_for_region_id]]
```

I think the search_query object would be helpful for developers to see what is available to them as opposed to just knowing the positional arguments available.

Thoughts?