### PR TITLE
Missing error parameter on catch statement with mtable.js

### DIFF
--- a/apps/_dashboard/static/components/mtable.js
+++ b/apps/_dashboard/static/components/mtable.js
@@ -109,7 +109,7 @@
             event.target.style.borderColor = "";
             return JSON.parse(event.target.value);
         }
-        catch{
+        catch (error) {
             event.target.style.borderColor = "#ff0000";
         }
     }


### PR DESCRIPTION
This is a syntax error. It shows with a non working db GUI editor with MS Edge on Windows