### PR TITLE
fix ?next= not followed at login

### DIFF
--- a/py4web/utils/auth.py
+++ b/py4web/utils/auth.py
@@ -893,6 +893,7 @@ class DefaultAuthForms:
             formstyle=self.formstyle,
         )
         user = None
+        self.auth.next["login"] = request.query.get("next")
         if form.submitted:
             user, error = self.auth.login(
                 form.vars.get("username"), form.vars.get("login_password")
@@ -903,11 +904,10 @@ class DefaultAuthForms:
                 self.auth.store_user_in_session(user["id"])
                 self._postprocessing("login", form, user)
         top_buttons = []
-        next = request.query.get("next")
         for name, plugin in self.auth.plugins.items():
             url = "../auth/plugin/" + name + "/login"
-            if next:
-                url = url + "?next=" + next
+            if self.auth.next["login"]:
+                url = url + "?next=" + self.auth.next["login"]
             top_buttons.append(A(plugin.label + " Login", _href=url, _role="button"))
         form.param.sidecar.append(
             A("Sign Up", _href="../auth/register", _class="info", _role="button")


### PR DESCRIPTION
When navigating to a page that requires login, after login you are taken back to the main index page instead of the intended page.  This fixes that problem.