### PR TITLE
Updated login to respect table field labels

### DIFF
--- a/py4web/utils/auth.py
+++ b/py4web/utils/auth.py
@@ -889,8 +889,15 @@ class DefaultAuthForms:
         return form
 
     def login(self):
+        fields = [Field("username",), Field("login_password", type="password")]
+        if self.auth.use_username:
+            fields[0].label = self.auth.db.auth_user.username.label
+        else:
+            fields[0].label = self.auth.db.auth_user.email.label
+        fields[1].label = self.auth.db.auth_user.password.label
+
         form = Form(
-            [Field("username"), Field("login_password", type="password")],
+            fields,
             submit_value="Sign In",
             formstyle=self.formstyle,
         )
@@ -926,7 +933,7 @@ class DefaultAuthForms:
 
     def request_reset_password(self):
         form = Form(
-            [Field("email", label="Username of Email")],
+            [Field("email", label="Username or Email")],
             submit_value="Request",
             formstyle=self.formstyle,
         )


### PR DESCRIPTION
A simple implementation of setting custom labels for the auth login. In response to this [post ](https://groups.google.com/g/py4web/c/zEVWn2uEAaU)on the group.

I'm sure there are some shorter methods of this, but given the password field in the table has readable/writable set to false, we can't just do something similar to register's [for field in fields]

(Also fixed a typo in lost password's page)