### PR TITLE
undo change to bulma select classes

### DIFF
--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -305,7 +305,7 @@ def FormStyleBulma(table, vars, errors, readonly, deletable):
         "input[type=submit]": "button",
         "input[type=password]": "input password",
         "input[type=file]": "file",
-        "select": "control input select",
+        "select": "control select",
         "textarea": "textarea",
     }
     return FormStyleDefault(table, vars, errors, readonly, deletable, classes)


### PR DESCRIPTION
Turns out adding the input class messed up the display.  Bulma needs to have the 'select' class on the element that is the select elements parent.  But, we can't do that with our implementation and I don't think we should.