### PR TITLE
improve URL

### DIFF
--- a/py4web/core.py
+++ b/py4web/core.py
@@ -580,7 +580,7 @@ def URL(
     hash=None,
     scheme=False,
     signer=None,
-    use_appname=True,
+    use_appname=None,
     static_version=None,
 ):
     """
@@ -591,6 +591,9 @@ def URL(
     URL('a','b',vars=dict(x=1),scheme='https') -> https://{domain}/{script_name?}/{app_name}/a/b?x=1
     URL('a','b',vars=dict(x=1),use_appname=False) -> /{script_name?}/a/b?x=1
     """
+    if use_appname is None:
+        use_appname = request.headers.get("x-py4web-appname")
+        use_appname = True if use_appname is None else not use_appname
     script_name = (
         request.environ.get("HTTP_X_SCRIPT_NAME", "")
         or request.environ.get("SCRIPT_NAME", "")

--- a/py4web/core.py
+++ b/py4web/core.py
@@ -1115,8 +1115,18 @@ def error_page(code, button_text=None, href="#", color=None, message=None):
 
 @bottle.error(404)
 def error404(error):
-    guess_app_name = request.path.split("/")[1]
-    return error_page(404, button_text=guess_app_name, href="/" + guess_app_name)
+    guess_app_name = 'index' if request.headers.get("x-py4web-appname") else request.path.split("/")[1]
+    if guess_app_name == 'index':
+        href = '/'
+    else:
+        href = '/' + guess_app_name
+    script_name = (
+        request.environ.get("HTTP_X_SCRIPT_NAME", "")
+        or request.environ.get("SCRIPT_NAME", "")
+    ).rstrip("/")
+    if script_name:
+        href = script_name + href
+    return error_page(404, button_text=guess_app_name, href=href)
 
 
 #########################################################################################

--- a/py4web/utils/auth.py
+++ b/py4web/utils/auth.py
@@ -142,7 +142,7 @@ class Auth(Fixture):
         password_complexity={"entropy": 50},
         block_previous_password_num=None,
         allowed_actions=["all"],
-        use_appname_in_redirects=True,
+        use_appname_in_redirects=None,
     ):
 
         self.param = Param(


### PR DESCRIPTION
allow to map domains to apps
example of usage:
```nginx
 map $http_host $appname {
       hostnames;
       foo.*   /some;  # foo.some.org  mapped to '/some' app
       .bar.com   /other;
 }
 server {
        listen       80;
        listen       [::]:80;
        server_name  foo.baz.org  www.bar.com  .example.*;

    location / {
        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header   Host $http_host;
        proxy_set_header   X-Real-IP $remote_addr;
        proxy_set_header   X-Forwarded-Host $server_name;
        proxy_redirect off;
        # for app that is not mapped we should just unset X-Py4web-Appname
        location /not_mapped_app/ {
                proxy_set_header X-Py4web-Appname "";
                proxy_pass http://unix:/run/gunicorn.sock;
        }
       # if this header is set and not empty then app is mapped => URL() should work with use_appname= False
        proxy_set_header X-Py4web-Appname $appname;

        # magic here  - we just add $appname to uri 
        # note that .example.* is not mapped and in this case $appname will be ""
        # so for  example.com  all apps  will be served in regular mode! i.e. as http://example.com/some 
        rewrite ^ $appname$request_uri break;
        proxy_pass http://unix:/run/gunicorn.sock;
    }
}


```