### PR TITLE
Ability to hide reference tables+checkbox display

### DIFF
--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -114,7 +114,17 @@ class FormStyleFactory:
                 continue
             # if the form is readonly or this is an id type field, display it as readonly
             if readonly or not field.writable or field.type == "id":
-                control = DIV(field.represent and field.represent(value) or value or "")
+                if field.type == "boolean":
+                        control = INPUT(
+                        _type="checkbox",
+                        _id=input_id,
+                        _name=field.name,
+                        _value="ON",
+                        _disabled="",
+                        _checked=value,
+                        _title=title,)
+                else:
+                        control = DIV(field.represent and field.represent(value) or value or "")
             # if we have a widget for the field use it
             elif field.widget:
                 control = field.widget(table, value)
@@ -185,7 +195,7 @@ class FormStyleFactory:
                     control.append(download_div)
                 control.append(LABEL("Change: "))
                 control.append(INPUT(_type="file", _id=input_id, _name=field.name))
-            elif get_options(field.requires) is not None:
+            elif get_options(field.requires) is not None and field.writable==True:
                 multiple = field.type.startswith("list:")
                 value = list(map(str, value if isinstance(value, list) else [value]))
                 option_tags = [


### PR DESCRIPTION
This PR creates the ability to hide the reference dropdown menu on the create form and make it readonly on the edit form. 
You can also hide it on the edit form if you set the referenced db field value to readonly=False in addition.

To goal is if you program a form for a table that is referenced by another table and your user is not supposed to 
have the choice to decouple the initially set reference. 

So you dont want that dropdown created when you have a field reference.. in essence.. and replace it with a default value, 
but that should not be transparent to the user.

In addition this adds consistent display of boolean values when set to True as checkboxes instead of displaying the Text "True". 

The checkbox code came from Jim Steil.