### PR TITLE
monkey patch bottle to allow for multi app routing in nginx

### DIFF
--- a/py4web/core.py
+++ b/py4web/core.py
@@ -129,6 +129,22 @@ def module2filename(module):
 
 
 ########################################################################################
+# fix request.fullpath for the case of domain mapping to app
+# (request.url will be autofixed, since it is based on request.fullpath)
+#########################################################################################
+def monkey_patch_bottle():
+    urljoin = urllib.parse.urljoin
+    @property
+    def fullpath(self):
+        appname = self.get_header('x-py4web-appname', '/')
+        return urljoin(self.script_name, self.path[len(appname):])
+    setattr(bottle.BaseRequest, 'fullpath', fullpath)
+
+
+monkey_patch_bottle()
+
+
+########################################################################################
 # Implement a O(1) LRU cache and memoize with expiration and monitoring (using linked list)
 #########################################################################################
 

--- a/py4web/utils/grid.py
+++ b/py4web/utils/grid.py
@@ -339,7 +339,7 @@ class Grid:
         #  instance variables that will be computed
         self.action = None
         self.current_page_number = None
-        self.endpoint = request.path
+        self.endpoint = request.fullpath
         if self.path:
             self.endpoint = self.endpoint[: -len(self.path)].rstrip("/")
         self.hidden_fields = None


### PR DESCRIPTION
With this commit and the following nginx config you can have different domains route to different applications under nginx

```
map $http_host $appname {
	hostnames;
	simple_table.* /simple_table;
	hiring_board.* /hiring_board;
        pr.* /pr;
        pythonbench.com /pythonbench;
	www.* /pythonbench;
}
server {
        listen          80;
        server_name     pythonbench.com simple_table.pythonbench.com pr.pythonbench.com hiring_board.pythonbench.com li1123-85.members.linode.com;
	client_max_body_size 20M;
	proxy_connect_timeout 10;
	proxy_send_timeout 15;
	proxy_read_timeout 20;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header Host $http_host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-Proto $scheme;
        proxy_set_header X-Forwarded-Host $server_name;
        proxy_redirect off;
	location / {
                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
                proxy_set_header Host $http_host;
                proxy_set_header X-Real-IP $remote_addr;
                proxy_set_header X-Forwarded-Proto $scheme;
                proxy_set_header X-Forwarded-Host $http_host;
		proxy_redirect off;
		location /not_mapped_app/ {
			proxy_set_header X-Py4web-Appname "";
			proxy_pass http://127.0.0.1:8000;
		}
		proxy_set_header X-Py4web-Appname $appname;
		rewrite ^ $appname$uri break;
		proxy_pass	http://127.0.0.1:8000;
	}
        location ~* ^/(\w+)/static(?:/_[\d]+\.[\d]+\.[\d]+)?/(.*)$ {
            alias /home/www-data/py4web/apps/$1/static/$2;
            expires max;
        }
}
```

Thanks to Val for creating the monkey patch and doing most (if not all) of the work. Please chime in here with any comments.

This also includes a change in grid to use request.fullpath instead of request.path.

Val also has some other ideas to improve this with more flexibility (see comments here -> #368 ) but I haven't had time to look that all over yet.