### PR TITLE
Honor 'represent' on columns when displaying in grid

### DIFF
--- a/py4web/utils/grid.py
+++ b/py4web/utils/grid.py
@@ -738,9 +738,15 @@ class Grid:
         :return:
         """
         if self.use_tablename:
-            field_value = row[field.tablename][field.name]
+            if 'represent' in field and field.represent:
+                field_value = self.db[field.tablename][field.name].represent(row[field.tablename][field.name])
+            else:
+                field_value = row[field.tablename][field.name]
         else:
-            field_value = row[field.name]
+            if 'represent' in field and field.represent:
+                field_value = self.db[field.tablename][field.name].represent(row[field.name])
+            else:
+                field_value = row[field.name]
         key = "%s.%s" % (field.tablename, field.name)
         formatter = (
             self.formatters.get(key)


### PR DESCRIPTION
honor the pydal represent keyword when displaying the table in grid