### PR TITLE
mandatory apps_folder on CLI new_app command, apps_folder must exist …

### DIFF
--- a/docs/chapter-03.rst
+++ b/docs/chapter-03.rst
@@ -267,7 +267,7 @@ with the **–help** or **-h** argument.
 .. code-block:: none
 
    # py4web new_app -h
-   Usage: py4web.py new_app [OPTIONS] [APPS_FOLDER] APP_NAME
+   Usage: py4web.py new_app [OPTIONS] APPS_FOLDER APP_NAME
 
      Create a new app copying the scaffolding one
 

--- a/py4web/core.py
+++ b/py4web/core.py
@@ -1421,7 +1421,7 @@ def shell(apps_folder):
 
 
 @cli.command()
-@click.argument("apps_folder")
+@click.argument("apps_folder", type=click.Path(exists=True))
 @click.argument("func")
 @click.option(
     "--args",
@@ -1464,7 +1464,7 @@ def set_password(password, password_file):
 
 
 @cli.command(name="new_app")
-@click.argument("apps_folder", default="apps")
+@click.argument("apps_folder", type=click.Path(exists=True))
 @click.argument("app_name")
 @click.option(
     "-s",


### PR DESCRIPTION
Mandatory APPS_FOLDER (path now checked for existence) on CLI call and new_app commands

Fixes #398