### PR TITLE
Updated mtable for additional features

### DIFF
--- a/apps/_dashboard/static/components/mtable.html
+++ b/apps/_dashboard/static/components/mtable.html
@@ -32,13 +32,15 @@
             <span v-else><i class="fa fa-square"></i> None</span>
           </span>
           <input class="input" v-else-if="field.type=='integer'" type="number" step="1" v-model="item[field.name]" v-bind:readonly="!editable">
-          <input class="input" v-else-if="field.type=='double'" type="number" step="0.01" v-model="item[field.name]" v-bind:readonly="!editable">
-          <input class="input" v-else-if="field.type=='decimal'" type="number" v-model="item[field.name]" v-bind:readonly="!editable">
+          <input class="input" v-else-if="field.type=='float'" type="number" step="0.00000000000001" v-model="item[field.name]"  v-bind:readonly="!editable">
+          <input class="input" v-else-if="field.type=='double'" type="number" step="0.00000000000001" v-model="item[field.name]" v-bind:readonly="!editable">
+          <input class="input" v-else-if="field.type=='decimal'" type="number" step="0.1" v-model="item[field.name]" v-bind:readonly="!editable">
           <input class="input" v-else-if="field.type=='date'" type="date" v-model="item[field.name]" v-bind:readonly="!editable">
           <input class="input" v-else-if="field.type=='time'" type="time" v-model="item[field.name]" v-bind:readonly="!editable">
           <input class="input" v-else-if="field.type=='datetime'" type="datetime-local" v-model="item[field.name]" v-bind:readonly="!editable">
           <input class="input" v-else-if="field.type=='password'" type="password" v-model="item[field.name]" v-bind:readonly="!editable">
           <input class="input" v-else-if="field.type=='list:integer'" type="text"  v-model="item[field.name]" v-bind:readonly="true">
+          <input class="input" v-else-if="field.type=='list:string'" type="text"  v-model="item[field.name]" v-bind:readonly="true">
           <input v-else-if="field.type=='upload'" type="text" v-model="item[field.name]" v-bind:readonly="!editable">
           <textarea class="textarea" v-else-if="field.type=='text'" v-model="item[field.name]" v-bind:readonly="!editable"></textarea>
           <select v-else-if="field.type=='reference'" v-model="item[field.name]" v-bind:readonly="!editable">
@@ -89,10 +91,12 @@
             <span v-else-if="field.type=='json'" class="field-string">(json)</span>
             <span v-else-if="field.type=='integer'" class="field-integer">{{item[field.name]}}</span>
             <span v-else-if="field.type=='double'" class="field-float">{{item[field.name]}}</span>
+            <span v-else-if="field.type=='float'" class="field-float">{{item[field.name]}}</span>
             <span v-else-if="field.type=='decimal'" class="field-float">{{item[field.name]}}</span>
             <span v-else-if="field.type=='date'" class="field-date">{{item[field.name]}}</span>
             <span v-else-if="field.type=='time'" class="field-time">{{item[field.name]}}</span>
             <span v-else-if="field.type=='list:integer'" class="field-string">{{item[field.name]}}</span>
+            <span v-else-if="field.type=='list:string'" class="field-string">{{item[field.name]}}</span>
             <span v-else-if="field.type=='datetime'" class="field-datetime">{{(item[field.name]||'').replace('T','@').substr(0,16)}}</span>
             <span v-else-if="field.type=='password'" class="field-password">{{item[field.name]}}</span>
             <span v-else-if="field.type=='boolean'" class="field-boolean">

--- a/apps/_dashboard/static/components/mtable.html
+++ b/apps/_dashboard/static/components/mtable.html
@@ -32,12 +32,13 @@
             <span v-else><i class="fa fa-square"></i> None</span>
           </span>
           <input class="input" v-else-if="field.type=='integer'" type="number" step="1" v-model="item[field.name]" v-bind:readonly="!editable">
-          <input class="input" v-else-if="field.type=='float'" type="number" v-model="item[field.name]" v-bind:readonly="!editable">
+          <input class="input" v-else-if="field.type=='double'" type="number" step="0.01" v-model="item[field.name]" v-bind:readonly="!editable">
           <input class="input" v-else-if="field.type=='decimal'" type="number" v-model="item[field.name]" v-bind:readonly="!editable">
           <input class="input" v-else-if="field.type=='date'" type="date" v-model="item[field.name]" v-bind:readonly="!editable">
           <input class="input" v-else-if="field.type=='time'" type="time" v-model="item[field.name]" v-bind:readonly="!editable">
           <input class="input" v-else-if="field.type=='datetime'" type="datetime-local" v-model="item[field.name]" v-bind:readonly="!editable">
           <input class="input" v-else-if="field.type=='password'" type="password" v-model="item[field.name]" v-bind:readonly="!editable">
+          <input class="input" v-else-if="field.type=='list:integer'" type="text"  v-model="item[field.name]" v-bind:readonly="true">
           <input v-else-if="field.type=='upload'" type="text" v-model="item[field.name]" v-bind:readonly="!editable">
           <textarea class="textarea" v-else-if="field.type=='text'" v-model="item[field.name]" v-bind:readonly="!editable"></textarea>
           <select v-else-if="field.type=='reference'" v-model="item[field.name]" v-bind:readonly="!editable">
@@ -87,10 +88,11 @@
             <span v-else-if="field.type=='string'" class="field-string">{{item[field.name]}}</span>
             <span v-else-if="field.type=='json'" class="field-string">(json)</span>
             <span v-else-if="field.type=='integer'" class="field-integer">{{item[field.name]}}</span>
-            <span v-else-if="field.type=='float'" class="field-float">{{item[field.name]}}</span>
+            <span v-else-if="field.type=='double'" class="field-float">{{item[field.name]}}</span>
             <span v-else-if="field.type=='decimal'" class="field-float">{{item[field.name]}}</span>
             <span v-else-if="field.type=='date'" class="field-date">{{item[field.name]}}</span>
             <span v-else-if="field.type=='time'" class="field-time">{{item[field.name]}}</span>
+            <span v-else-if="field.type=='list:integer'" class="field-string">{{item[field.name]}}</span>
             <span v-else-if="field.type=='datetime'" class="field-datetime">{{(item[field.name]||'').replace('T','@').substr(0,16)}}</span>
             <span v-else-if="field.type=='password'" class="field-password">{{item[field.name]}}</span>
             <span v-else-if="field.type=='boolean'" class="field-boolean">


### PR DESCRIPTION
Mtable in the dashboard works great for viewing tables, but a few attributes don't display in there.

The table assumes that rational numbers are displayed if the `field.type == 'float'` but float doesn't seem to be a type in pydal going off the documentation online, instead the field can either be double or decimal.

In addition it doesn't support displaying the pydal `list:<>` type. This current version has `list:integer` integrated with it, but it wouldn't be too terrible to add the others as well in a future commit. Note that this will display the value as a comma-delineated list in brackets, and to update it you have to keep the same syntax, but it does allow the field to even appear in the table.