### PR TITLE
Fixed signing of URLs that change when URLencoded

### DIFF
--- a/py4web/core.py
+++ b/py4web/core.py
@@ -656,7 +656,9 @@ def URL(
     # Signs the URL if required.  Copy vars into urlvars not to modify it.
     urlvars = dict(vars) if vars else {}
     if signer:
-        signer.sign_vars(url, urlvars)
+        # Note that we need to sign the non-urlencoded URL, since
+        # at verification time, it will be already URLdecoded.
+        signer.sign_vars(prefix + "/".join(broken_parts), urlvars)
     if urlvars:
         url += "?" + "&".join(
             "%s=%s" % (k, urllib.parse.quote(str(v))) for k, v in urlvars.items()

--- a/py4web/utils/url_signer.py
+++ b/py4web/utils/url_signer.py
@@ -97,7 +97,16 @@ class URLSigner(Fixture):
         return key
 
     def get_url_key(self, url, variables):
-        # The key consists of the key, and of the URL parameters.
+        """Buids a signing key. The signing key consists of:
+        - The key proper, which is generally taken from the session
+          (see _get_key method above)
+        - An additional key, consisting in the information to sign:
+          - The URL
+          - Information, if given
+          - variables to sign
+        The key proper and additional key are concatenated and returned.
+        """
+        # The key consists of the url, and of the URL parameters.
         additional_key = {
             "url": url,
             "info": self.signing_info() if self.signing_info is not None else "",


### PR DESCRIPTION
There was a bug, whereby URLs that change when URLencoded were not properly signed/verified. 

The issue is that at verification time, the URL has already beed URL-decoded (this I guess is automatic in bottle). 
So, one must sign the key before URL encoding it. 

I also added a few comments, just for clarity. 
