### PR TITLE
Removed jwt from URLSigner in favor of the simpler hashlib

### DIFF
--- a/apps/examples/controllers_components.py
+++ b/apps/examples/controllers_components.py
@@ -40,7 +40,7 @@ from .components.vueform import VueForm, InsertForm, TableForm
 from .components.fileupload import FileUpload
 from .components.starrater import StarRater
 
-signed_url = URLSigner(session)
+signed_url = URLSigner(session, lifespan=3600)
 
 
 # -----------------------------

--- a/py4web/core.py
+++ b/py4web/core.py
@@ -657,7 +657,7 @@ def URL(
     if signer:
         # Note that we need to sign the non-urlencoded URL, since
         # at verification time, it will be already URLdecoded.
-        signer.sign_vars(prefix + "/".join(broken_parts), urlvars)
+        signer.sign(prefix + "/".join(broken_parts), urlvars)
     if urlvars:
         url += "?" + "&".join(
             "%s=%s" % (k, urllib.parse.quote(str(v))) for k, v in urlvars.items()


### PR DESCRIPTION
I removed the use of jwt from the URLSigner in favor of the simpler hashlib.  This enables also more careful control of what goes into the signature, including the salt.  The main motivation of the PR is to avoid breakages due to jwt incompatibilities before and after version 2.0.0. 
