### PR TITLE
All Field Validation Being Skipped

### DIFF
--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -477,11 +477,13 @@ class Form(object):
                     for field in self.table:
                         if field.writable and field.type != "id":
                             original_value = post_vars.getall(field.name)
-                            if (
-                                isinstance(original_value, list)
-                                and len(original_value) == 1
-                            ):
-                                original_value = original_value[0]
+                            if isinstance(original_value, list):
+                                if len(original_value) == 1:
+                                    original_value = original_value[0]
+                                    
+                                elif len(original_value) == 0:
+                                    original_value = None
+                                    
                             if field.type.startswith("list:") and isinstance(
                                 original_value, str
                             ):
@@ -503,7 +505,8 @@ class Form(object):
                                     value = self.record.get(field.name)
                                 else:
                                     value = None
-                            validated_vars[field.name] = value
+                            if value:
+                                validated_vars[field.name] = value
                             if error:
                                 self.errors[field.name] = error
                     self.vars.update(validated_vars)

--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -475,8 +475,6 @@ class Form(object):
                 if not post_vars.get("_delete"):
                     validated_vars = {}
                     for field in self.table:
-                        if not post_vars.get(field.name):
-                            continue
                         if field.writable and field.type != "id":
                             original_value = post_vars.getall(field.name)
                             if (

--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -505,7 +505,7 @@ class Form(object):
                                     value = self.record.get(field.name)
                                 else:
                                     value = None
-                            if value:
+                            if value is not None:
                                 validated_vars[field.name] = value
                             if error:
                                 self.errors[field.name] = error


### PR DESCRIPTION
The form field validation is being skipped when the values provided are either not present or they are empty strings so therefore it always accepts an empty form being POSTed with the formname and formkey set.

The removal of code skipping form validation if the field is not present in post_vars resolves #472 in which you can currently register a user without any details.

### Empty Registration Form No Longer Registers User:
![Empty Registration Form](https://user-images.githubusercontent.com/6424306/110760661-cd4c0400-82b3-11eb-884f-a4a2037919b2.PNG)
