### PR TITLE
Validation of Uploads in Forms

### DIFF
--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -181,7 +181,7 @@ class FormStyleFactory:
                 )
             elif field.type == "upload":
                 control = DIV()
-                if value:
+                if value and not error:
                     download_div = DIV()
                     download_div.append(
                         LABEL(
@@ -496,7 +496,7 @@ class Form(object):
                                 value = request.files.get(field.name)
                                 delete = post_vars.get("_delete_" + field.name)
                                 if value is not None:
-                                    if field.uploadfolder:
+                                    if field.uploadfolder and not error:
                                         value = field.store(
                                             value.file,
                                             value.filename,


### PR DESCRIPTION
Currently even if the form's validation fires and a file upload doesn't pass the `field.requires` field, it will still upload and store the file. 

Personally I believe that the file should only be uploaded _if_ the file passes all validations.

This is also the same with downloading the file, we would only want that if the file successfully uploaded.