### PR TITLE
Fix issue with delete action in grid.py

### DIFF
--- a/py4web/utils/grid.py
+++ b/py4web/utils/grid.py
@@ -491,7 +491,7 @@ class Grid:
         elif self.action == "delete":
             db(db[self.tablename].id == self.record_id).delete()
 
-            url = parse_referer()
+            url = parse_referer(request)
             if url and url.query:
                 self.endpoint += "?%s" % url.query
             redirect(self.endpoint)


### PR DESCRIPTION
Delete actions were failing because parse_referrer requires request object.