### PR TITLE
Added radio button widget and gave no.css some radio button love

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -166,4 +166,4 @@ Many thanks to everybody, and especially:
 - `Pirsch <https://github.com/Pirsch>`__
 - `sugizo <https://github.com/sugizo>`__
 - `valq7711 <https://github.com/valq7711>`__
-- `Kkeller83 <https://github.com/Kkeller83>`__
+- `Kevin Keller <https://github.com/Kkeller83>`__

--- a/apps/_scaffold/static/css/no.css
+++ b/apps/_scaffold/static/css/no.css
@@ -230,8 +230,12 @@ fieldset {
   padding: 0;
 }
 
-input[type='checkbox'], input[type='radio'] {
+input[type='checkbox'] {
   display: inline;
+}
+
+input[type="radio"]{
+  margin: 0 10px 0 10px;
 }
 
 [disabled] {

--- a/py4web/core.py
+++ b/py4web/core.py
@@ -328,7 +328,7 @@ class DAL(pydal.DAL, Fixture):
 # make sure some variables in pydal are thread safe
 def thread_safe_pydal_patch():
     Field = pydal.DAL.Field
-    tsafe_attrs = ["readable", "writable", "default", "update", "requires"]
+    tsafe_attrs = ["readable", "writable", "default", "update", "requires","widget"]
     for a in tsafe_attrs:
         setattr(Field, a, threadsafevariable.ThreadSafeVariable())
 

--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -321,6 +321,14 @@ class FormStyleFactory:
 
                 field_value = None
                 field_type = 'file'
+                
+            elif get_options(field.requires) is not None and field.writable==True and field.widget=="radio":
+                multiple = field.type.startswith("list:")
+                control=DIV()
+                value = list(map(str, value if isinstance(value, list) else [value]))
+                for k, v in get_options(field.requires)[1:]:
+                    control.append(INPUT(v, _value=k, _label=k,_name=field.name, _type="radio", _checked=(not k is None and k in value)))
+                    control.append(LABEL(k, _for=k))
 
             elif get_options(field.requires) is not None and field.writable == True:
                 multiple = field.type.startswith("list:")


### PR DESCRIPTION
Added the radio button widget as an alternative for dropdowns in the html forms.py. 
If a field has a "required" validation set the db.field.widget="radio" option can be set to display fields as radio buttons. 
no.css has received some spacing for radio buttons so they look neat. 