### PR TITLE
Fixes to form defaults and Auth defaults

### DIFF
--- a/py4web/utils/auth.py
+++ b/py4web/utils/auth.py
@@ -172,11 +172,11 @@ class Auth(Fixture):
         registration_requires_confirmation=True,
         registration_requires_approval=False,
         inject=True,
-        extra_fields=[],
+        extra_fields=None,
         login_expiration_time=3600,  # seconds
-        password_complexity={"entropy": 50},
+        password_complexity=None,
         block_previous_password_num=None,
-        allowed_actions=["all"],
+        allowed_actions=None,
         use_appname_in_redirects=None,
     ):
 
@@ -185,9 +185,9 @@ class Auth(Fixture):
             registration_requires_approval=registration_requires_approval,
             login_after_registration=False,
             login_expiration_time=login_expiration_time,  # seconds
-            password_complexity=password_complexity,
+            password_complexity=password_complexity or {"entropy": 50},
             block_previous_password_num=block_previous_password_num,
-            allowed_actions=allowed_actions,
+            allowed_actions=allowed_actions or ["all"],
             use_appname_in_redirects=use_appname_in_redirects,
             formstyle=FormStyleDefault,
             messages=copy.deepcopy(self.MESSAGES),
@@ -213,9 +213,8 @@ class Auth(Fixture):
         self.use_username = use_username  # if False, uses email only
         self.use_phone_number = use_phone_number
         # The self._link variable is not thread safe (only intended for testing)
-        self.extra_auth_user_fields = extra_fields
+        self.extra_auth_user_fields = extra_fields or []
         self._link = None
-        self.extra_auth_user_fields = extra_fields
         if db and define_tables:
             self.define_tables()
         self.plugins = {}

--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -96,7 +96,7 @@ class FormStyleFactory:
         for field in table:
 
             input_id = "%s_%s" % (field.tablename, field.name)
-            value = vars.get(field.name, field.default)
+            value = vars.get(field.name, field.default() if callable(field.default) else field.default)
             error = errors.get(field.name)
             field_class = "type-" + field.type.split()[0].replace(":", "-")
             placeholder = (
@@ -607,7 +607,7 @@ class Form(object):
         if not self.record and not self.keep_values:
             self.vars.clear()
             for field in self.table:
-                self.vars[field.name] = field.default
+                self.vars[field.name] = field.default() if callable(field.default) else field.default
 
     def helper(self):
         if self.accepted:

--- a/py4web/utils/url_signer.py
+++ b/py4web/utils/url_signer.py
@@ -118,6 +118,7 @@ class URLSigner(Fixture):
         """Gets the signing key, creating it if necessary."""
         if self.session is None:
             key = self.key
+            assert self.key is not None, "You need to specify a signing key"
         else:
             key = self.session.get("_signature_key")
             if key is None:


### PR DESCRIPTION
This PR fixes two different problems. 

First, the code for a form did not account for the possibility that the field default is a callable. 
But this is useful to do: 

```
def get_user_email():
    return auth.current_user.get('email') if auth.current_user else None

db.define_table(
    'prova',
    Field('user_email', default=get_user_email),
    Field('name'),
)
```

so that the default for `user_email` is the email of that one particular user.  Pydal respects this, but the form does not.  This is now fixed.  I wonder if there are other related bugs (is the code for grid correct?). 

The other problem this fixes is the defaults for the `__init__` method of `Auth`; some of them had default value set to a mutable, which in Python is dangerous. 


