### PR TITLE
classes, styles and actionbuttons are now callable in a grid

### DIFF
--- a/py4web/utils/grid.py
+++ b/py4web/utils/grid.py
@@ -1006,6 +1006,8 @@ class Grid:
                                 # if None was returned, no button is available for this row: ignore this value in the
                                 # list
                                 continue
+                        if btn.onclick:
+                            btn.url = None
                         td.append(
                             self.render_action_button(
                                 btn.url,

--- a/py4web/utils/grid.py
+++ b/py4web/utils/grid.py
@@ -630,6 +630,18 @@ class Grid:
                 " ".join(items) if isinstance(items, (list, tuple)) else " %s" % items
             )
 
+        if callable(additional_classes):
+            additional_classes = additional_classes(row)
+
+        if callable(additional_styles):
+            additional_styles = additional_styles(row)
+
+        if callable(override_classes):
+            override_classes = override_classes(row)
+
+        if callable(override_styles):
+            override_styles = override_styles(row)
+
         if override_classes:
             classes = join(override_classes)
         elif additional_classes:
@@ -912,6 +924,14 @@ class Grid:
                 td = TD(_class=classes, _style=styles)
                 if self.param.pre_action_buttons:
                     for btn in self.param.pre_action_buttons:
+                        if callable(btn):
+                            # a button can be a callable, to indicate whether or not a button should
+                            # be displayed. call the function with the row object
+                            btn = btn(row)
+                            if btn is None:
+                                # if None was returned, no button is available for this row: ignore this value in the
+                                # list
+                                continue
                         if btn.onclick:
                             btn.url = None
                         td.append(
@@ -978,8 +998,14 @@ class Grid:
                     )
                 if self.param.post_action_buttons:
                     for btn in self.param.post_action_buttons:
-                        if btn.onclick:
-                            btn.url = None
+                        if callable(btn):
+                            # a button can be a callable, to indicate whether or not a button should
+                            # be displayed. call the function with the row object
+                            btn = btn(row)
+                            if btn is None:
+                                # if None was returned, no button is available for this row: ignore this value in the
+                                # list
+                                continue
                         td.append(
                             self.render_action_button(
                                 btn.url,


### PR DESCRIPTION
with this change, the classes, styles and action buttons are now callable.

example usage:
```python
@action("example/<path:path>")
def example(path=None):

    pre_action_buttons = [
        lambda row: ActionButton(
            URL("test", row.id),
            text="Click me",
            icon="fa-plus",
            additional_classes=row.id,
            additional_styles=["height: 10px" if row.bar else None],
        )
    ]

    post_action_buttons = [
        lambda row: ActionButton(
            URL("test", row.id),
            text="Click me!!!",
            icon="fa-plus",
            additional_classes=row.id,
            additional_styles=["height: 10px" if row.bar else None],
        )
    ]

    grid = Grid(
        path=path,
        query=db.foo,
        pre_action_buttons=pre_action_buttons,
        post_action_buttons=post_action_buttons,
    )

    return dict(grid=grid.render())
```