### PR TITLE
DOCS:  Fix Search on documentation - issue #490

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 ### optional, used for documentation only ###
 
+docutils==0.16
 PyStemmer
 sphinx
 sphinx-tabs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 ### optional, used for documentation only ###
 
+PyStemmer
 sphinx
 sphinx-tabs
 sphinx_rtd_theme


### PR DESCRIPTION
A missing required module (PyStemmer) cause the html search to fail