### PR TITLE
Extend deletable behavior to grid's edit form

### DIFF
--- a/py4web/utils/grid.py
+++ b/py4web/utils/grid.py
@@ -455,6 +455,7 @@ class Grid:
                 db[self.tablename],
                 record=self.record_id,
                 readonly=readonly,
+                deletable=self.param.deletable,
                 formstyle=self.param.formstyle,
                 **attrs,
             )


### PR DESCRIPTION
Without this proposed fix, if a Grid object is instantiated with the parameter deletable = False, the grid's default form for the "edit" action still includes a "check to delete" checkbox.

This fix makes the inclusion of the "check to delete" checkbox dependent on the value of the grid's deletable parameter, so the checkbox is included on the "edit" action form when deletable = True and not included when deletable = False.