### PR TITLE
Made the local objects used in Flash, Session, request-local objects 

### DIFF
--- a/py4web/__init__.py
+++ b/py4web/__init__.py
@@ -20,6 +20,7 @@ from .core import (
     Translator,  # from pluralize
     Session,
     Cache,
+    Current,
     Flash,
     user_in,  # additional fixtures
     URL,  # custom helper

--- a/py4web/core.py
+++ b/py4web/core.py
@@ -351,6 +351,37 @@ thread_safe_pydal_patch()
 # this global object will be used to store their state to restore it for every http request
 ICECUBE = {}
 
+
+#########################################################################################
+# Current Fixture
+#########################################################################################
+
+class Current(Fixture):
+    """
+    This fixture gives access to a request-local object, that is cleaned
+    after each request.
+    """
+
+    def __init__(self):
+        self.local = None
+
+    def on_request(self):
+        self.local = threading.local()
+        self.local.data = {}
+
+    def finalize(self):
+        self.local = None
+
+    def __setitem__(self, key, value):
+        self.local.data[key] = value
+
+    def __getitem__(self, key):
+        return self.local.data[key]
+
+    def get(self, key, default=None):
+        return self.local.data.get(key, default)
+
+
 #########################################################################################
 # Flash Fixture
 #########################################################################################


### PR DESCRIPTION
I made the thread-local objects used in Flash, Session, request-local in addition to thread local. 
I also added a Current object that can be used to obtain user-level request-local objects. 
Finally, I added a finalize() method to fixtures, that is guaranteed to be called both in case of success or failure; this can be useful (for instance, I use it to ensure that the request-local objects are erased after the request). 
