### PR TITLE
formatters for row add new class and styles

### DIFF
--- a/py4web/utils/grid.py
+++ b/py4web/utils/grid.py
@@ -905,10 +905,18 @@ class Grid:
                 row_id = row["id"]
                 self.use_tablename = False
 
+            key = "%s.%s" % (self.tablename, '__row')
+            if self.formatters.get(key):
+                extra_class = self.formatters.get(key)(row)['_class']
+                extra_style = self.formatters.get(key)(row)['_style']
+            else:
+                extra_class= ''
+                extra_style= '
+
             tr = TR(
                 _role="row",
-                _class=self.param.grid_class_style.classes.get("grid-tr"),
-                _style=self.param.grid_class_style.styles.get("grid-tr"),
+                _class=self.param.grid_class_style.classes.get("grid-tr") + " " + extra_class,
+                _style=self.param.grid_class_style.styles.get("grid-tr") + " " + extra_style,
             )
             #  add all the fields to the row
             for index, field in enumerate(self.param.fields):

--- a/py4web/utils/grid.py
+++ b/py4web/utils/grid.py
@@ -911,7 +911,7 @@ class Grid:
                 extra_style = self.formatters.get(key)(row)['_style']
             else:
                 extra_class= ''
-                extra_style= '
+                extra_style= ''
 
             tr = TR(
                 _role="row",

--- a/py4web/utils/grid.py
+++ b/py4web/utils/grid.py
@@ -918,11 +918,10 @@ class Grid:
             else:
                 extra_class= ''
                 extra_style= ''
-
             tr = TR(
                 _role="row",
-                _class=self.param.grid_class_style.classes.get("grid-tr") + " " + extra_class,
-                _style=self.param.grid_class_style.styles.get("grid-tr") + " " + extra_style,
+                _class=join_classes(self.param.grid_class_style.classes.get("grid-tr"),extra_class),
+                _style=join_classes(self.param.grid_class_style.styles.get("grid-tr"), extra_style),
             )
             #  add all the fields to the row
             for index, column in enumerate(self.param.columns):


### PR DESCRIPTION
To use formatter to row:

grid.formatters['table_name.__row'] = lambda value:  ....

The lambda return   dict(_class='bg-danger',_style= ' ')

