### PR TITLE
fix FieldVirtual with multiple tables display in grid

### DIFF
--- a/py4web/utils/grid.py
+++ b/py4web/utils/grid.py
@@ -801,9 +801,6 @@ class Grid:
         return div
 
     def render_table_header(self):
-
-        up = I(**self.param.grid_class_style.get("grid-sorter-icon-up"))
-        dw = I(**self.param.grid_class_style.get("grid-sorter-icon-down"))
         columns = []
         sort_order = request.query.get("orderby", "")
 
@@ -841,6 +838,9 @@ class Grid:
         return thead
 
     def render_field_header(self, field, field_index, sort_order):
+        up = I(**self.param.grid_class_style.get("grid-sorter-icon-up"))
+        dw = I(**self.param.grid_class_style.get("grid-sorter-icon-down"))
+
         key = "%s.%s" % (field.tablename, field.name)
         heading = (
             self.param.headings[field_index]

--- a/py4web/utils/grid.py
+++ b/py4web/utils/grid.py
@@ -248,7 +248,9 @@ class Column:
 class Grid:
 
     FORMATTERS_BY_TYPE = {
-        "boolean": lambda value: INPUT(_type="checkbox", _checked=value)
+        "boolean": lambda value: INPUT(
+            _type="checkbox", _checked=value, _disabled="disabled"
+        )
         if value
         else "",
         "datetime": lambda value: XML(


### PR DESCRIPTION
Grid fails if you have a virtual field and a left join (multiple tables).  This code fixes it.

If there is a virtual or custom field in the grid fields then we 

1. Include all param.columns fields that are not virtual or custom
2. Look at each virtual/custom field and add all fields from their table as they might be needed for processing

