### PR TITLE
Spellchecking Documentation and mtable/logging adjustments

### DIFF
--- a/apps/_dashboard/static/components/mtable.js
+++ b/apps/_dashboard/static/components/mtable.js
@@ -1,71 +1,73 @@
-(function(){
+(function () {
 
-    var mtable = { props: ['url', 'filter', 'order', 'editable', 'create', 'deletable', 'render'], data: null, methods: {}};
-    
-    mtable.data = function() {        
-        var data = {url: this.url,
-                    busy: false,
-                    filter: this.filter || '',
-                    order: this.order ||  '',
-                    errors: {},
-                    item: null,
-                    message: '',
-                    reference_options: {},
-                    table: { model: [], items: [], count: 0}};
+    var mtable = { props: ['url', 'filter', 'order', 'editable', 'create', 'deletable', 'render'], data: null, methods: {} };
+
+    mtable.data = function () {
+        var data = {
+            url: this.url,
+            busy: false,
+            filter: this.filter || '',
+            order: this.order || '',
+            errors: {},
+            item: null,
+            message: '',
+            reference_options: {},
+            table: { model: [], items: [], count: 0 }
+        };
         mtable.methods.load.call(data);
         return data;
     };
-    
-    mtable.methods.toggle = function(obj, key) {
+
+    mtable.methods.toggle = function (obj, key) {
         obj[key] = !obj[key];
     };
-    mtable.methods.load = function() {
+    mtable.methods.load = function () {
         let self = this;
         let length = this.table.items.length;
         let url = this.url + '?@limit=20';
-        if (length) url+='&@offset='+length; else url+='&@model=true';
-        let filters = self.filter.split(' and ').filter((f)=>{return f.trim() != ''});
-        filters = filters.filter((f)=>{return f.trim();}).map((f)=>{                
-                let parts = (f
-                             .replace(/ equals? /,'==')
-                             .replace('==','.eq=')
-                             .replace('!=','.ne=')
-                             .replace('<','.lt=')
-                             .replace('>','.gt=')
-                             .replace('<=','.le=')
-                             .replace('>=','.ge=')
-                             .replace(' in ','.in=')
-                             .replace(' startswith ','~')
-                             .replace('~','startswith=')
-                             .split(/[=]/));
-                let negate = false; 
-                if (parts[0].substr(0,4) == 'not ') {
-                    negate=true; 
-                    parts[0]=parts[0].substr(4);
-                }
-                return ((negate?'not.':'') + 
-                        parts[0].replace(/ /ig,'') +
-                        '=' + parts[parts.length-1].replace(/^ /,''));
-            });
-        if (filters.length) url += '&'+filters.join('&');
-        if (self.order) url += '&@order='+self.order;
+        if (length) url += '&@offset=' + length; else url += '&@model=true';
+        let filters = self.filter.split(' and ').filter((f) => { return f.trim() != '' });
+        filters = filters.filter((f) => { return f.trim(); }).map((f) => {
+            let parts = (f
+                .replace(/ equals? /, '==')
+                .replace('==', '.eq=')
+                .replace('!=', '.ne=')
+                .replace('<', '.lt=')
+                .replace('>', '.gt=')
+                .replace('<=', '.le=')
+                .replace('>=', '.ge=')
+                .replace(' in ', '.in=')
+                .replace(' startswith ', '~')
+                .replace('~', 'startswith=')
+                .split(/[=]/));
+            let negate = false;
+            if (parts[0].substr(0, 4) == 'not ') {
+                negate = true;
+                parts[0] = parts[0].substr(4);
+            }
+            return ((negate ? 'not.' : '') +
+                parts[0].replace(/ /ig, '') +
+                '=' + parts[parts.length - 1].replace(/^ /, ''));
+        });
+        if (filters.length) url += '&' + filters.join('&');
+        if (self.order) url += '&@order=' + self.order;
         self.busy = true;
         axios.get(url).then(function (res) {
-                self.busy = false;
-                if(!length) self.table = res.data; 
-                else self.table.items = self.table.items.concat(res.data.items);
-            });
+            self.busy = false;
+            if (!length) self.table = res.data;
+            else self.table.items = self.table.items.concat(res.data.items);
+        });
     };
-    
+
     mtable.methods.reorder = function (field) {
         if (this.order == '~' + field.name) this.order = null;
-        else if (this.order == field.name) this.order = '~'+field.name;
+        else if (this.order == field.name) this.order = '~' + field.name;
         else this.order = field.name;
         this.table.items = [];
         this.load();
     };
 
-    mtable.methods.clear = function() {
+    mtable.methods.clear = function () {
         this.errors = {};
         this.item = null;
         this.message = '';
@@ -74,37 +76,43 @@
     mtable.methods.open_create = function () {
         this.populate_reference_options();
         this.item = {};
-        for(var field in this.model) this.item[field.name] = field.default||'';
+        for (var field of this.table.model) {
+            output = field.default != null ? field.default : '';
+            if (field.type == "datetime") {
+                output = output.split('.')[0];
+            }
+            Vue.set(this.item, field.name, output);
+        }
     };
-    
+
     mtable.methods.open_edit = function (item) {
         this.populate_reference_options();
         this.item = {};
         this.item = item;
     };
 
-    mtable.methods.populate_reference_options = function(){
+    mtable.methods.populate_reference_options = function () {
         let self = this;
-        for(var field of this.table.model){
+        for (var field of this.table.model) {
             console.log(field.name);
-            if(field.type == "reference"){
-                if (!(field.references in this.reference_options)){
+            if (field.type == "reference") {
+                if (!(field.references in this.reference_options)) {
                     Vue.set(this.reference_options, field.references, []);
-                    let reference_table_url = self.url.split('/');                    
+                    let reference_table_url = self.url.split('/');
                     reference_table_url.pop()
                     reference_table_url.push(field.references)
                     reference_table_url = reference_table_url.join('/') + '?@options_list=true';
                     axios.get(reference_table_url).then(function (res) {
                         let url_components = res.config.url.split('?')[0].split('/');
-                        self.reference_options[url_components[url_components.length - 1 ]] = res.data.items;
-                     });
-                    
+                        self.reference_options[url_components[url_components.length - 1]] = res.data.items;
+                    });
+
                 }
             }
         }
     }
 
-    mtable.methods.parse_and_validate_json = function(event){
+    mtable.methods.parse_and_validate_json = function (event) {
         try {
             event.target.style.borderColor = "";
             return JSON.parse(event.target.value);
@@ -116,29 +124,29 @@
 
     mtable.methods.trash = function (item) {
         if (window.confirm("Really delete record?")) {
-            let url = this.url + '/' + item.id;            
-            this.table.items = this.table.items.filter((i)=>{return i.id != item.id;});
+            let url = this.url + '/' + item.id;
+            this.table.items = this.table.items.filter((i) => { return i.id != item.id; });
             axios.delete(url);
-            if (item==this.item) this.item = null;
+            if (item == this.item) this.item = null;
         }
     };
-    
+
     mtable.methods.save = function (item) {
         let url = this.url;
         self.busy = true;
         if (item.id) {
             url += '/' + item.id;
             axios.put(url, item).then(mtable.handle_response('put', this),
-                                      mtable.handle_response('put', this));
+                mtable.handle_response('put', this));
         } else {
             axios.post(url, item).then(mtable.handle_response('post', this),
-                                       mtable.handle_response('post', this));
+                mtable.handle_response('post', this));
         }
     };
 
-    mtable.handle_response = function(method, data) {
+    mtable.handle_response = function (method, data) {
         self.busy = false;
-        return function(res) {
+        return function (res) {
             if (res.response) res = res.response; // deal with error weirdness
             if (method == 'post') {
                 data.table.items = [];
@@ -161,38 +169,38 @@
     mtable.methods.close = function () {
         this.clear();
     };
-    
-    mtable.methods.search = function () { 
+
+    mtable.methods.search = function () {
         this.clear();
         this.table.items = [];
         this.table.count = 0;
         this.load();
     };
 
-    mtable.methods.go_ref_by = function(tablefield, item_id) {
-        tablefield = (tablefield+'.id').split('.');
+    mtable.methods.go_ref_by = function (tablefield, item_id) {
+        tablefield = (tablefield + '.id').split('.');
         var tablename = tablefield[0], fieldname = tablefield[1];
         var source = window.location.search.substring(1);
-        var vars={}, items=source.split('&');
-        items.map(function(item){
-                var pair = item.split('=');
-                vars[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1]);
-            });
+        var vars = {}, items = source.split('&');
+        items.map(function (item) {
+            var pair = item.split('=');
+            vars[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1]);
+        });
         vars['tablename'] = tablename
-        vars['filter'] = fieldname+'=='+item_id;
-        source = Object.keys(vars).map(function(key){
-                return key+'='+encodeURIComponent(vars[key]);
-            }).join('&');
-        window.location = window.location.href.split('?')[0]+'?'+source;
+        vars['filter'] = fieldname + '==' + item_id;
+        source = Object.keys(vars).map(function (key) {
+            return key + '=' + encodeURIComponent(vars[key]);
+        }).join('&');
+        window.location = window.location.href.split('?')[0] + '?' + source;
     };
 
 
 
     var scripts = document.getElementsByTagName('script');
-    var src = scripts[scripts.length-1].src;
-    var path = src.substr(0, src.length-3) + '.html';
-    Q.register_vue_component('mtable', path, function(template) {        
-            mtable.template = template.data;
-            return mtable;
-        });
+    var src = scripts[scripts.length - 1].src;
+    var path = src.substr(0, src.length - 3) + '.html';
+    Q.register_vue_component('mtable', path, function (template) {
+        mtable.template = template.data;
+        return mtable;
+    });
 })();

--- a/apps/_dashboard/static/components/mtable.js
+++ b/apps/_dashboard/static/components/mtable.js
@@ -1,73 +1,71 @@
-(function () {
+(function(){
 
-    var mtable = { props: ['url', 'filter', 'order', 'editable', 'create', 'deletable', 'render'], data: null, methods: {} };
-
-    mtable.data = function () {
-        var data = {
-            url: this.url,
-            busy: false,
-            filter: this.filter || '',
-            order: this.order || '',
-            errors: {},
-            item: null,
-            message: '',
-            reference_options: {},
-            table: { model: [], items: [], count: 0 }
-        };
+    var mtable = { props: ['url', 'filter', 'order', 'editable', 'create', 'deletable', 'render'], data: null, methods: {}};
+    
+    mtable.data = function() {        
+        var data = {url: this.url,
+                    busy: false,
+                    filter: this.filter || '',
+                    order: this.order ||  '',
+                    errors: {},
+                    item: null,
+                    message: '',
+                    reference_options: {},
+                    table: { model: [], items: [], count: 0}};
         mtable.methods.load.call(data);
         return data;
     };
-
-    mtable.methods.toggle = function (obj, key) {
+    
+    mtable.methods.toggle = function(obj, key) {
         obj[key] = !obj[key];
     };
-    mtable.methods.load = function () {
+    mtable.methods.load = function() {
         let self = this;
         let length = this.table.items.length;
         let url = this.url + '?@limit=20';
-        if (length) url += '&@offset=' + length; else url += '&@model=true';
-        let filters = self.filter.split(' and ').filter((f) => { return f.trim() != '' });
-        filters = filters.filter((f) => { return f.trim(); }).map((f) => {
-            let parts = (f
-                .replace(/ equals? /, '==')
-                .replace('==', '.eq=')
-                .replace('!=', '.ne=')
-                .replace('<', '.lt=')
-                .replace('>', '.gt=')
-                .replace('<=', '.le=')
-                .replace('>=', '.ge=')
-                .replace(' in ', '.in=')
-                .replace(' startswith ', '~')
-                .replace('~', 'startswith=')
-                .split(/[=]/));
-            let negate = false;
-            if (parts[0].substr(0, 4) == 'not ') {
-                negate = true;
-                parts[0] = parts[0].substr(4);
-            }
-            return ((negate ? 'not.' : '') +
-                parts[0].replace(/ /ig, '') +
-                '=' + parts[parts.length - 1].replace(/^ /, ''));
-        });
-        if (filters.length) url += '&' + filters.join('&');
-        if (self.order) url += '&@order=' + self.order;
+        if (length) url+='&@offset='+length; else url+='&@model=true';
+        let filters = self.filter.split(' and ').filter((f)=>{return f.trim() != ''});
+        filters = filters.filter((f)=>{return f.trim();}).map((f)=>{                
+                let parts = (f
+                             .replace(/ equals? /,'==')
+                             .replace('==','.eq=')
+                             .replace('!=','.ne=')
+                             .replace('<','.lt=')
+                             .replace('>','.gt=')
+                             .replace('<=','.le=')
+                             .replace('>=','.ge=')
+                             .replace(' in ','.in=')
+                             .replace(' startswith ','~')
+                             .replace('~','startswith=')
+                             .split(/[=]/));
+                let negate = false; 
+                if (parts[0].substr(0,4) == 'not ') {
+                    negate=true; 
+                    parts[0]=parts[0].substr(4);
+                }
+                return ((negate?'not.':'') + 
+                        parts[0].replace(/ /ig,'') +
+                        '=' + parts[parts.length-1].replace(/^ /,''));
+            });
+        if (filters.length) url += '&'+filters.join('&');
+        if (self.order) url += '&@order='+self.order;
         self.busy = true;
         axios.get(url).then(function (res) {
-            self.busy = false;
-            if (!length) self.table = res.data;
-            else self.table.items = self.table.items.concat(res.data.items);
-        });
+                self.busy = false;
+                if(!length) self.table = res.data; 
+                else self.table.items = self.table.items.concat(res.data.items);
+            });
     };
-
+    
     mtable.methods.reorder = function (field) {
         if (this.order == '~' + field.name) this.order = null;
-        else if (this.order == field.name) this.order = '~' + field.name;
+        else if (this.order == field.name) this.order = '~'+field.name;
         else this.order = field.name;
         this.table.items = [];
         this.load();
     };
 
-    mtable.methods.clear = function () {
+    mtable.methods.clear = function() {
         this.errors = {};
         this.item = null;
         this.message = '';
@@ -84,35 +82,35 @@
             Vue.set(this.item, field.name, output);
         }
     };
-
+    
     mtable.methods.open_edit = function (item) {
         this.populate_reference_options();
         this.item = {};
         this.item = item;
     };
 
-    mtable.methods.populate_reference_options = function () {
+    mtable.methods.populate_reference_options = function(){
         let self = this;
-        for (var field of this.table.model) {
+        for(var field of this.table.model){
             console.log(field.name);
-            if (field.type == "reference") {
-                if (!(field.references in this.reference_options)) {
+            if(field.type == "reference"){
+                if (!(field.references in this.reference_options)){
                     Vue.set(this.reference_options, field.references, []);
-                    let reference_table_url = self.url.split('/');
+                    let reference_table_url = self.url.split('/');                    
                     reference_table_url.pop()
                     reference_table_url.push(field.references)
                     reference_table_url = reference_table_url.join('/') + '?@options_list=true';
                     axios.get(reference_table_url).then(function (res) {
                         let url_components = res.config.url.split('?')[0].split('/');
-                        self.reference_options[url_components[url_components.length - 1]] = res.data.items;
-                    });
-
+                        self.reference_options[url_components[url_components.length - 1 ]] = res.data.items;
+                     });
+                    
                 }
             }
         }
     }
 
-    mtable.methods.parse_and_validate_json = function (event) {
+    mtable.methods.parse_and_validate_json = function(event){
         try {
             event.target.style.borderColor = "";
             return JSON.parse(event.target.value);
@@ -124,29 +122,29 @@
 
     mtable.methods.trash = function (item) {
         if (window.confirm("Really delete record?")) {
-            let url = this.url + '/' + item.id;
-            this.table.items = this.table.items.filter((i) => { return i.id != item.id; });
+            let url = this.url + '/' + item.id;            
+            this.table.items = this.table.items.filter((i)=>{return i.id != item.id;});
             axios.delete(url);
-            if (item == this.item) this.item = null;
+            if (item==this.item) this.item = null;
         }
     };
-
+    
     mtable.methods.save = function (item) {
         let url = this.url;
         self.busy = true;
         if (item.id) {
             url += '/' + item.id;
             axios.put(url, item).then(mtable.handle_response('put', this),
-                mtable.handle_response('put', this));
+                                      mtable.handle_response('put', this));
         } else {
             axios.post(url, item).then(mtable.handle_response('post', this),
-                mtable.handle_response('post', this));
+                                       mtable.handle_response('post', this));
         }
     };
 
-    mtable.handle_response = function (method, data) {
+    mtable.handle_response = function(method, data) {
         self.busy = false;
-        return function (res) {
+        return function(res) {
             if (res.response) res = res.response; // deal with error weirdness
             if (method == 'post') {
                 data.table.items = [];
@@ -169,38 +167,38 @@
     mtable.methods.close = function () {
         this.clear();
     };
-
-    mtable.methods.search = function () {
+    
+    mtable.methods.search = function () { 
         this.clear();
         this.table.items = [];
         this.table.count = 0;
         this.load();
     };
 
-    mtable.methods.go_ref_by = function (tablefield, item_id) {
-        tablefield = (tablefield + '.id').split('.');
+    mtable.methods.go_ref_by = function(tablefield, item_id) {
+        tablefield = (tablefield+'.id').split('.');
         var tablename = tablefield[0], fieldname = tablefield[1];
         var source = window.location.search.substring(1);
-        var vars = {}, items = source.split('&');
-        items.map(function (item) {
-            var pair = item.split('=');
-            vars[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1]);
-        });
+        var vars={}, items=source.split('&');
+        items.map(function(item){
+                var pair = item.split('=');
+                vars[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1]);
+            });
         vars['tablename'] = tablename
-        vars['filter'] = fieldname + '==' + item_id;
-        source = Object.keys(vars).map(function (key) {
-            return key + '=' + encodeURIComponent(vars[key]);
-        }).join('&');
-        window.location = window.location.href.split('?')[0] + '?' + source;
+        vars['filter'] = fieldname+'=='+item_id;
+        source = Object.keys(vars).map(function(key){
+                return key+'='+encodeURIComponent(vars[key]);
+            }).join('&');
+        window.location = window.location.href.split('?')[0]+'?'+source;
     };
 
 
 
     var scripts = document.getElementsByTagName('script');
-    var src = scripts[scripts.length - 1].src;
-    var path = src.substr(0, src.length - 3) + '.html';
-    Q.register_vue_component('mtable', path, function (template) {
-        mtable.template = template.data;
-        return mtable;
-    });
+    var src = scripts[scripts.length-1].src;
+    var path = src.substr(0, src.length-3) + '.html';
+    Q.register_vue_component('mtable', path, function(template) {        
+            mtable.template = template.data;
+            return mtable;
+        });
 })();

--- a/docs/chapter-01.rst
+++ b/docs/chapter-01.rst
@@ -57,8 +57,8 @@ details if you come from web2py):
 -  PY4WEB, unlike web2py, does not create a new environment at every
    request. It introduces the concept of fixtures to explicitly declare
    which objects need to be (re)initialized when a new http request arrives
-   or need cleaup when completed. This makes it much faster than web2py.
--  PY4WEB, has a new sesson object which, like web2py’s, provides strong
+   or need cleanup when completed. This makes it much faster than web2py.
+-  PY4WEB, has a new session object which, like web2py’s, provides strong
    security and encryption of the session data, but sessions are no
    longer stored in the file system - which created performance issues.
    It provides sessions in cookies, in redis, in memcache, or optionally  in
@@ -89,7 +89,7 @@ details if you come from web2py):
    basic functionality of register, login, logout, change password,
    request change password, edit profile as well as integration with
    PAM, SAML2, LDAP, OAUTH2 (google, facebook, and twitter).
--  PY4WEB leverages PyDAL'new tags functionality
+-  PY4WEB leverages PyDAL's new tags functionality
    to tag users with groups and search users by groups and
    apply permissions based on membership.
 -  PY4WEB comes with with some custom Vue.js components designed to

--- a/docs/chapter-02.rst
+++ b/docs/chapter-02.rst
@@ -42,7 +42,7 @@ There are many tutorials and videos available. Here are some of them:
 The sources on GitHub
 ---------------------
 
-Last but not least, py4web is Open Source, with a BSD v3 licence, hosted on GitHub at https://github.com/web2py/py4web. This means that you can read, study and experiment
+Last but not least, py4web is Open Source, with a BSD v3 license, hosted on GitHub at https://github.com/web2py/py4web. This means that you can read, study and experiment
 with all of its internal details by yourself.
 
 
@@ -63,7 +63,7 @@ A modern python workplace
 
 In the following chapters you will start coding on your computer. We suggest you to setup a modern python workplace if you plan to do it efficiently and safely.
 Even for running simple examples and experimenting a little, we strongly suggest to use an **Integrated Development Environment** (IDE). This will make your programming experience much better, allowing syntax checking, linting and visual debugging.
-Nowadays there are two free and multiplatform main choices: Microsoft Visual Studio Code aka `VScode <https://code.visualstudio.com/>`__ and
+Nowadays there are two free and multi-platform main choices: Microsoft Visual Studio Code aka `VScode <https://code.visualstudio.com/>`__ and
 JetBrains `PyCharm <https://www.jetbrains.com/pycharm/>`__.
 
 When you'll start to deal with more complex programs and need reliability,
@@ -94,7 +94,7 @@ In PyCharm, if you should get gevent errors you need to enable Settings | Build,
 How to contribute
 =================
 
-We need help from everyone: support our efforts! You can just partecipate in the Google group trying to answer other's questions, submit bugs using or create pull requests on the GitHub
+We need help from everyone: support our efforts! You can just participate in the Google group trying to answer other's questions, submit bugs using or create pull requests on the GitHub
 repository.
 
 If you wish to correct and expand this manual, or even translate it in a new foreign language, you can read all the needed information directly on the

--- a/docs/chapter-03.rst
+++ b/docs/chapter-03.rst
@@ -2,7 +2,7 @@
 Installation and Startup
 ========================
 
-Understing the design
+Understanding the design
 ---------------------
 
 Before everything else it is important to understand that unlike other web frameworks,
@@ -11,7 +11,7 @@ is in charge of starting a apps. For this reason you need two things:
 - the py4web module (which you download from out web site, from pypi, from github)
 - one or more folders containing collections of apps you want to run.
 py4web has command line options to create a folder with some example apps,
-to intialize an dexisting folder, and to add scaffolding apps to that folder.
+to initialize an existing folder, and to add scaffolding apps to that folder.
 Once installed you can have multiple apps under the same folder running concurrently
 and served by the same py4web process at the same address and port.
 An apps folder is a python module, and each app is also a python module.
@@ -69,7 +69,7 @@ From the command line
 
    python3 -m pip install --upgrade py4web --no-cache-dir --user
 
-Also, if ``python3`` does not work, try specify a full verion as in ``python3.8``.
+Also, if ``python3`` does not work, try specify a full version as in ``python3.8``.
 
 This will install py4web and all its dependencies on the system’s path
 only. The assets folder (that contains the py4web’s system apps) will
@@ -87,7 +87,7 @@ path. On Windows, a special py4web.exe file (pointing to py4web.py) will
 be created by *pip* on the system’s path, but not if you type the
 *–user* option by mistake.
 
-Istalling using a virtual environment
+Installing using a virtual environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A full installation of any complex python application like py4web will
@@ -208,7 +208,7 @@ If you installed py4web from pip you can simple upgrade it with
    made changes to those apps.
 
 If you installed py4web in any other way, you must upgrade it manually.
-First you have to make a backup of any personal py4web work you’ve done,
+First you have to make a backup of any personal py4web work you've done,
 then delete the old installation folder and re-install the framework
 again.
 
@@ -515,7 +515,7 @@ WSGI
 
 py4web is a standard WSGI application. So, if a full program installation it's not
 feasible you can simply run py4web as a WSGI app. For example, using gunicorn-cli,
-create a pyton file:
+create a python file:
 
 .. code:: python
 

--- a/docs/chapter-04.rst
+++ b/docs/chapter-04.rst
@@ -3,7 +3,7 @@ The Dashboard
 =============
 
 The Dashboard is the standard web based IDE; you will surely use it
-extensively to manage the applications and check databases.
+extensively to manage the applications and check your databases.
 Looking at its interface is a good way to start exploring py4web and
 its components.
 
@@ -15,7 +15,7 @@ When you run the standard py4web program, it starts a web server with a
 main web page listening on http://127.0.0.1:8000 (which means that it is
 listening on the TCP port 8000 on your local PC, using the HTTP protocol).
 
-You can connect to this main page only from your local pc, using a web
+You can connect to this main page only from your local PC, using a web
 browser like Firefox or Google Chrome:
 
 .. FIXME: why do this image fit into the pdf page while the others do not?

--- a/docs/chapter-05.rst
+++ b/docs/chapter-05.rst
@@ -34,7 +34,7 @@ If you now restart py4web or
 press the “Reload Apps” in the Dashboard, py4web will find this module,
 import it, and recognize it as an app, simply because of its location.
 You can also run py4web in *watch* mode (see the :ref:`run command option`) for
-automatic reloading of the apps wheneve it changes, which is very useful in a development environment.
+automatic reloading of the apps whenever it changes, which is very useful in a development environment.
 In this case, run py4web with a command like this:
 
 
@@ -417,7 +417,7 @@ But in fact any other files inside an app can be watched by setting a
 handler function using the ``@app_watch_handler`` decorator.
 
 Two examples of this usage are reported now. Do not worry if you don’t
-fully undestand them: the key point here is that even non-python code
+fully understand them: the key point here is that even non-python code
 could be reloaded automatically if you explicit it with the
 ``@app_watch_handler`` decorator.
 

--- a/docs/chapter-06.rst
+++ b/docs/chapter-06.rst
@@ -173,7 +173,7 @@ Now create the following translation file ``translations/en.json``:
    }
 
 When visiting this site with the browser language preference set to
-english and reloading multiple times you will get the following
+English and reloading multiple times you will get the following
 messages:
 
 ::
@@ -290,7 +290,7 @@ to implement a counter.
        return "counter = %i" % counter
 
 The counter will start from 0; its value will be remembered and
-increased everytime you reload the page.
+increased every time you reload the page.
 
 .. image:: images/simple_counter.png
 
@@ -298,7 +298,7 @@ Opening the page in a new browser tab will give you the updated
 counter value. Closing and reopening the browser, or opening a
 new *private window*, will instead restart the counter from 0.
 
-Usually the informations saved in the session object are related
+Usually the information is saved in the session object are related
 to the user - like its username, preferences, last pages visited,
 shopping cart and so on. The session object has the same interface
 as a Python dictionary but in py4web sessions are always stored using
@@ -328,7 +328,7 @@ set. Other parameters can be specified as well:
 
 Here:
 
--  ``secret`` is the passphrase used to sign the informations
+-  ``secret`` is the passphrase used to sign the information
 -  ``expiration`` is the maximum lifetime of the session, in seconds
    (default = None, i.e. no timeout)  
 -  ``algorithm`` is the algorithm to be used for the JWT token
@@ -451,7 +451,7 @@ sessions on your local filesystem:
 
 We leave to you as an exercise to implement expiration, limit the number
 of files per folder by using subfolders, and implement file locking. Yet
-we do not recomment storing sessions on the filesystem: it is
+we do not recommend storing sessions on the filesystem: it is
 inefficient and does not scale well.
 
 The URLsigner fixture
@@ -490,7 +490,7 @@ accessing the database, not just sessions.
 PY4WEB, by default, uses the **PyDAL** (Python Database Abstraction Layer)
 which is documented in the next chapter. Here is an example, please
 remember to create the ``databases`` folder under your project in case
-it doesn’t exist:
+it doesn't exist:
 
 .. code:: python
 
@@ -607,7 +607,7 @@ fields:
        form = Form(db.thing)
        return dict(form=form)
 
-Note thas this code will only be able to display a form, to process it
+Note that this code will only be able to display a form, to process it
 after submit, additional code needs to be added, as we will see later
 on. This example is assuming that you created the application from the
 scaffolding app, so that a generic.html is already created for you.

--- a/docs/chapter-07.rst
+++ b/docs/chapter-07.rst
@@ -48,7 +48,7 @@ recent adapters.
 
    In any modern python distribution **SQLite** is actually built-in as a Python library.
    The SQLite driver (sqlite3) is also included: you don't need to install it.
-   Hence this is the most popular database for testing and developement.
+   Hence this is the most popular database for testing and development.
 
 The Windows and the Mac binary distribution work out of the box with SQLite only.
 To use any other database back end, run a full py4web
@@ -186,7 +186,7 @@ that is available using the :ref:`shell command option`.
 .. warning::
 
    Mind that
-   database changes may be persistent. So be carefull and do NOT exitate
+   database changes may be persistent. So be careful and do NOT exitate
    to create a new application for doing testing instead of tampering
    with an existing one.
 
@@ -569,7 +569,7 @@ tables
 ``commit`` and ``rollback``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The insert, truncate, delete, and update operations aren’t actually
+The insert, truncate, delete, and update operations aren't actually
 committed until py4web issues the commit command. The create and drop
 operations may be executed immediately, depending on the database
 engine.
@@ -931,7 +931,7 @@ only for fields of type “string”. ``uploadfield``, ``authorize``, and
    table if a value for this field is not explicitly specified.
 -  ``requires`` is a **validator** or a list of validators. This is not used
    by the DAL, but instead it is used by ``Form`` (this will be explained
-   better on the :ref:`Forms` chapther). The default validators for
+   better on the :ref:`Forms` chapter). The default validators for
    the given types are shown in the next section
    :ref:`Field types and validators`.
 
@@ -2029,7 +2029,7 @@ attribute, you can list them in the “fields” argument:
    repr_row = row.render(0, fields=[db.mytable.myfield])
 
 Note, it returns a transformed copy of the original Row, so there’s no
-update_record (which you wouldn’t want anyway) or delete_record.
+update_record (which you wouldn't want anyway) or delete_record.
 
 Shortcuts
 ~~~~~~~~~
@@ -4272,7 +4272,7 @@ Database cascades
 Database schema can define relationships which trigger deletions of
 related records, known as cascading. The DAL is not informed when a
 record is deleted due to a cascade. So no \*_delete callaback will ever
-be called as conseguence of a cascade-deletion.
+be called as consequence of a cascade-deletion.
 
 Record versioning
 ~~~~~~~~~~~~~~~~~
@@ -4764,7 +4764,7 @@ in the following dictionary also in “dal.py”:
      - pydal.adapters.mssql.Vertica
 
 the uri string is then parsed in more detail by the adapter itself.
-An updated list of adapters can be obtaind as dictionary with
+An updated list of adapters can be obtained as dictionary with
 
 .. code: python
 

--- a/docs/chapter-08.rst
+++ b/docs/chapter-08.rst
@@ -3,15 +3,15 @@ The RESTAPI
 ===========
 
 Since version 19.5.10 pyDAL includes a restful API called RestAPI. It is
-inspired by GraphQL but it’s not quite the same because it is less
-powerful but, in the spirit of py4web, more practical and easier to use.
+inspired by GraphQL and while it’s not quite the same due to it being less
+powerful, it is in the spirit of py4web where it's more practical and easier to use.
 Like GraphQL RestAPI allows a client to query for information using the
 GET method and allows to specify some details about the format of the
 response (which references to follow, and how to denormalize the data).
 Unlike GraphQL it allows the server to specify a policy and restrict
 which queries are allowed and which one are not. They can be evaluated
 dynamically per request based on the user and the state of the server.
-As the name implied RestAPI allows all stardard methods GET, POST, PUT,
+As the name implied RestAPI allows all standard methods: GET, POST, PUT,
 and DELETE. Each of them can be enabled or disabled based on the policy,
 for individual tables and individual fields.
 
@@ -104,7 +104,7 @@ The general query has the form ``{something}.eq=value`` where ``eq=``
 stands for “equal”, ``gt=`` stands for “greater than”, etc. The
 expression can be prepended by ``not.``.
 
-``{something}`` can be the name of a field in the table been queried as
+``{something}`` can be the name of a field in the table being queried as
 in:
 
 **All superheroes called “Superman”**
@@ -113,7 +113,7 @@ in:
 
    /superheroes/api/superhero?name.eq=Superman
 
-It can be the name of a field of a table referred by the table been
+It can be the name of a field of a table referred by the table being
 queried as in:
 
 **All superheroes with real identity “Clark Kent”**
@@ -122,7 +122,7 @@ queried as in:
 
    /superheroes/api/superhero?real_identity.name.eq=Clark Kent
 
-It can be the name of a field of a table that refers to the table neen
+It can be the name of a field of a table that refers to the table being
 queried as in:
 
 **All superheroes with any tag superpower with strength > 90**
@@ -655,7 +655,7 @@ OUTPUT:
        "api_version": "0.1"
    }
 
-URL (it's a single line, splitted for readability):
+URL (it's a single line, split for readability):
 
 ::
 
@@ -757,7 +757,7 @@ OUTPUT:
        "api_version": "0.1"
    }
 
-URL (it's a single line, splitted for readability):
+URL (it's a single line, split for readability):
 
 ::
 
@@ -839,7 +839,7 @@ OUTPUT:
        "api_version": "0.1"
    }
 
-URL (it's a single line, splitted for readability):
+URL (it's a single line, split for readability):
 
 ::
 

--- a/docs/chapter-09.rst
+++ b/docs/chapter-09.rst
@@ -26,7 +26,7 @@ to use those editors to create py4web templates.
     
 Since the developer is embedding Python code into HTML, the document
 should be indented according to HTML rules, and not Python rules.
-Therefore, we allow unindented Python inside the ``[[ ... ]]`` tags.
+Therefore, we allow un-indented Python inside the ``[[ ... ]]`` tags.
 But since Python normally uses indentation to delimit blocks of code, we
 need a different way to delimit them; this is why the py4web template
 language makes use of the Python keyword ``pass``.
@@ -530,7 +530,7 @@ You can override these default content blocks by enclosing your new
 content inside the same block name. The location of the block in the
 layout.html is not changed, but the contents is.
 
-Here is a simplifed version. Imagine this is “layout.html”:
+Here is a simplified version. Imagine this is “layout.html”:
 
 .. code:: html
 

--- a/docs/chapter-11.rst
+++ b/docs/chapter-11.rst
@@ -8,7 +8,7 @@ Pluralize
 Pluralize is a Python library for Internationalization (i18n) and
 Pluralization (p10n).
 
-The library assumes a folder (for exaple “translations”) that contains
+The library assumes a folder (for example “translations”) that contains
 files like:
 
 ::
@@ -83,7 +83,7 @@ Add newly discovered entries in all supported languages
 
    T.update_languages(matches)
 
-Add a new supported language (for example german, “de”)
+Add a new supported language (for example German, “de”)
 
 ::
 

--- a/docs/chapter-12.rst
+++ b/docs/chapter-12.rst
@@ -108,7 +108,7 @@ Note that:
    the form is contained
 
 
-This example it's not so useful because it's not using a database, a template or the session management.
+This example is not so useful because it's not using a database, a template or the session management.
 But it works, and if you try to fill the form with an empty product_quantity, the form will trigger an error
 and the corresponding error page will be shown.
 
@@ -171,12 +171,29 @@ contains the following code:
 
 Reload py4web and visit http://127.0.0.1:8000/form_basic : 
 the result is an input form on the top of the page, and the list of all the
-previuos added entries on the bottom:
+previously added entries on the bottom:
 
 .. image:: images/form2.png
 
 
 The database content can also be fully seen and changed with the Dashboard app.
+
+Form Structure Manipulation
+---------------------------
+
+Like in web2py, in py4web a form is rendered by helpers. Unlike web2py, it uses yatl helpers. This means the
+tree structure of a form can be manipulated before the form is serialized in HTML. For example:
+
+.. code:: python
+
+    db.define_table('paint', Field('color'))
+    form = Form(db.paint)
+    form.structure.find('[name=color]')[0]['_class'] = 'my-class'
+
+Notice that a form does not make an HTML tree until form structure is accessed. Once accessed you can use `.find(...)`
+to find matching elements. The argument of `find` is a string following the filter syntax of jQuery. In the above case
+there is a single match `[0]` and we modify the `_class` attribute of that element. Attribute names of HTML elements
+must be preceded by an underscore.
 
 Form validation
 ---------------
@@ -199,7 +216,7 @@ Here is a simple example of how to require a validator for a table field:
     )
 
 The validator is frequently
- written explicity outside the table definition in this equivalent manner:
+ written explicitly outside the table definition in this equivalent manner:
 
 .. code:: python
 
@@ -236,7 +253,7 @@ Built-in validators have constructors that take an ``error_message`` argument:
     IS_NOT_EMPTY(error_message='cannot be empty!')
 
 
-It'optional and it allows you to override the default error message for any validator.
+It's optional and it allows you to override the default error message for any validator.
 Also, it's the usually fist option of the constructors and you can normally avoid to name it. Hence
 the following syntax is equivalent:
 
@@ -726,7 +743,7 @@ The zero argument is optional and it determines the text of the option selected 
 is not accepted by the ``IS_IN_SET`` validator itself. If you do not want a "choose one" option, set ``zero=None``.
 
 The elements of the set can be combined with a numerical validator, as long as IS_IN_SET is first in the list.
-Doing so wil force conversion by the last validator to the numerical type. So, IS_IN_SET can be followed by
+Doing so will force conversion by the last validator to the numerical type. So, IS_IN_SET can be followed by
 ``IS_INT_IN_RANGE`` (which converts the value to int) or ``IS_FLOAT_IN_RANGE`` (which converts the value to float). For example:
 
 .. code:: python
@@ -804,7 +821,7 @@ where:
    ``^!!@#$%^&*()_+-=?<>,.:;{}[]|`` (you can customize these using ``specials = '...'``)
 -  ``upper`` is the minimum number of upper case characters
   
-other accepected arguments are:
+other accepted arguments are:
 
 -  ``invalid`` for the list of forbidden characters, by default ``invalid=' "'``
 -  ``max`` for the maximum length of the value
@@ -925,7 +942,7 @@ This validator is specifically designed to work with the following field:
 Notice that due to the ``widget`` customization this field will be rendered by a textarea in SQLFORMs (see next [[Widgets #Widgets]]
 section). This let you insert and edit multiple emails in a single input field (very much like normal mail client programs do),
 separating each email address with ``,``, ``;``, and blanks (space, newline, and tab characters).
-As a conseguence now we need a validator which is able to operate on a single value input and a way to split the validated value into
+As a consequence now we need a validator which is able to operate on a single value input and a way to split the validated value into
 a list to be next processed by DAL, these are what the ``requires`` and ``filter_in`` arguments stand for.
 As alternative to ``filter_in``, you can pass the following function to the ``onvalidation`` argument of form ``accepts``, ``process``,
 or ``validate`` method:
@@ -1481,21 +1498,3 @@ Here is an example:
            # Do something with form.vars['product_name'] and form.vars['product_quantity']
            redirect(URL('index'))
        return dict(form=form)
-
-
-Form Structure Manipulation
----------------------------
-
-Like in web2py, in py4web a form is rendered by helpers. Unlike web2py, it uses yatl helpers. This means the
-tree structure of a form can be manipulated before the form is serialized in HTML. For example:
-
-.. code:: python
-
-    db.define_table('paint', Field('color'))
-    form = Form(db.paint)
-    form.structure.find('[name=color]')[0]['_class'] = 'my-class'
-
-Notice that a form does not make an HTML tree until form structure is accessed. Once accessed you can use `.find(...)`
-to find matching elements. The argument of `find` is a string following the filter syntax of jQuery. In the above case
-there is a single match `[0]` and we modify the `_class` attribute of that element. Attribute names of HTML elements
-must be preceded by an underscore.

--- a/docs/chapter-13.rst
+++ b/docs/chapter-13.rst
@@ -129,7 +129,7 @@ Auth Plugins
 ------------
 
 Plugins are defined in “py4web/utils/auth_plugins” and they have a
-hierachical structure. Some are exclusive and some are not. For example,
+hierarchical structure. Some are exclusive and some are not. For example,
 default, LDAP, PAM, and SAML are exclusive (the developer has to pick
 one). Default, Google, Facebook, and Twitter OAuth are not exclusive
 (the developer can pick them all and the user gets to choose using the
@@ -266,18 +266,18 @@ to enable the following syntax:
 
 **Important:** ``Tags`` are automatically hierarchical. For example, if
 a user has a group tag ‘teacher/high-school/physics’, then all the
-following seaches will return the user:
+following searches will return the user:
 
 -  ``groups.find('teacher/high-school/physics')``
 -  ``groups.find('teacher/high-school')``
 -  ``groups.find('teacher')``
 
-This means that slashes have a special meaning for tags. Slahes at the
+This means that slashes have a special meaning for tags. Slashes at the
 beginning or the end of a tag are optional. All other chars are allowed
 on equal footing.
 
 Notice that one table can have multiple associated ``Tags`` objects. The
-name groups here is completely arbitary but has a specific semantic
+name groups here is completely arbitrary but has a specific semantic
 meaning. Different ``Tags`` objects are orthogonal to each other. The
 limit to their use is your creativity.
 

--- a/docs/chapter-14.rst
+++ b/docs/chapter-14.rst
@@ -137,7 +137,7 @@ If you provide a search_queries list to grid, it will:
 
 -  build a search form. If more than one search query in the list, it
    will also generate a dropdown to select which search field to search
-   agains
+   against
 -  gather filter values and filter the grid
 
 However, if this doesn’t give you enough flexibility you can provide

--- a/docs/chapter-15.rst
+++ b/docs/chapter-15.rst
@@ -47,11 +47,11 @@ Some of the main differences are the following:
 - In web2py the mapping between URLs and file/function names is automatic but it can be
   overwritten in “routes.py” (like in Django). In py4web the mapping is specified in the decorator
   as in `@action('my_url_path')` (like in Bottle and Flask). Notice that if the path starts with
-  “/” it is assumed to be an absolute path. If not, it is assumed to be reative and prepended by
+  “/” it is assumed to be an absolute path. If not, it is assumed to be realive and prepended by
   the “/{appname}/” prefix. Also, if the path ends with “/index”, the latter postfix is assumed
   to be optional.
 
-- In web2py the path extention matters and “http://*.html” is expected to return HTML while
+- In web2py the path extension matters and “http://*.html” is expected to return HTML while
   “http://*.json” is expected to return JSON, etc. In py4web there is no such convention. If the
   action returns a dict() and has a template, the dict() will be rendered by the template, else it
   will be rendered in JSON. More complex behavior can be accomplished using decorators.
@@ -82,7 +82,7 @@ Some of the main differences are the following:
   only variables that can be changed at will are the following field attributes: readable,
   writable, requires, update, default. All the others are for practical purposes to be
   considered global and non thread safe. This is also the reason that makes using
-  :ref:`Lazy Tables` with py4web unuseful and even dangerous.
+  :ref:`Lazy Tables` with py4web useless and even dangerous.
 
 - Both web2py and pyweb have an Auth object which serve the same purpose. Both objects have the
   ability to generate forms pretty much in the same manner. The py4web ones is defined to be more

--- a/docs/chapter-16.rst
+++ b/docs/chapter-16.rst
@@ -10,7 +10,7 @@ py4web and asyncio
 py4web (as bottle) is thread-based, with high speed and efficient memory usage.
 Asyncio is not strictly needed, at least for most of the normal use
 cases where it will add problems more than value because of its concurrency model.
-On the other hand, we think py4web needs a buil-in websocket async based solution.
+On the other hand, we think py4web needs a built-in websocket async based solution.
 
 If you plan to play with asyncio be careful that you should also deal with all
 the framework's components: in particular pydal is not asyncio compliant because

--- a/py4web/utils/tags.py
+++ b/py4web/utils/tags.py
@@ -1,4 +1,4 @@
 import logging
 from pydal.tools.tags import Tags
 
-logging.warn("Deprecation notice: replace py4web.utils.tags with pydal.tools.tags in your code.")
+logging.warning("Deprecation notice: replace py4web.utils.tags with pydal.tools.tags in your code.")


### PR DESCRIPTION
- I have gone over all the documentation RST files with a spell checker and made adjustments where I saw fit to errors. Note that I did not go over every file for grammar adjustments and flow, this is solely misspelled words.

- In addition, fixed an issue with Vue's reactivity on the mtable in the _dashboard to fix #552 and allow booleans to be adjusted on create.

- I noticed an issue with the default implementation of dates and the rest api. This may be more of a pydal issue, but on a GET for the REST api on a table with a date, the field.default contains milliseconds. However, the default `IS_DATETIME` validator does not want milliseconds. These two seem to be contradictions of each other and I'm not sure if it can be fixed on the `py4web` side. For now, I've just removed the milliseconds from the default string on all datetimes.

- Finally, `logging.warn` is depricated and `logging.warning` should be used. I replaced that accordingly in `py4web.utils.tags`

P.S. _(@nicozanf it might be a good idea to include [this spell-check package](https://github.com/sphinx-contrib/spelling) within the documentation readme as a suggestion for developers to use in the future so we can catch errors early on. It can be configured to ignore certain words so `web2py` `py4web` and generic software development could be ignored)_