### PR TITLE
mailer attachments and minor grid format

### DIFF
--- a/py4web/utils/grid.py
+++ b/py4web/utils/grid.py
@@ -162,6 +162,7 @@ class GridClassStyleBulma(GridClassStyle):
         "grid-tr": "",
         "grid-th": "",
         "grid-td": "",
+        "grid-button": "grid-button button is-small",
         "grid-details-button": "grid-details-button button is-small",
         "grid-edit-button": "grid-edit-button button is-small",
         "grid-delete-button": "grid-delete-button button is-small",
@@ -1125,7 +1126,9 @@ class Grid:
                     override_classes=self.param.grid_class_style.classes.get(
                         "grid-new-button", ""
                     ),
-                    override_styles=self.param.grid_class_style.styles.get("grid-new-button"),
+                    override_styles=self.param.grid_class_style.styles.get(
+                        "grid-new-button"
+                    ),
                 )
             )
 


### PR DESCRIPTION
Mailing with an attachment was broken.  See this google groups link -> https://groups.google.com/g/py4web/c/MFr8DwDGvic

The update to mailer.py addresses it but should be reviewed by someone familiar with mailing in python.

The update to grid is a minor bulma styling fix.