### PR TITLE
Fixing Default Style for Grid

### DIFF
--- a/py4web/utils/grid.py
+++ b/py4web/utils/grid.py
@@ -97,7 +97,7 @@ class GridClassStyle:
     styles = {
         "grid-wrapper": "",
         "grid-header": "display: table; width: 100%",
-        "grid-new-button": "display: table-cell;",
+        "grid-new-button": "",
         "grid-search": "display: table-cell; float:right",
         "grid-table-wrapper": "overflow-x: auto; width:100%",
         "grid-table": "",


### PR DESCRIPTION
I removed  display: table-cell from  "grid-new-button":, because it makes the new button in the standard grid look massive and out of place. Removign this makes it look nice again.