### PR TITLE
Fix Scaffold app to use pydal.tools.tags

### DIFF
--- a/apps/_scaffold/common.py
+++ b/apps/_scaffold/common.py
@@ -9,7 +9,7 @@ from py4web import Session, Cache, Translator, Flash, DAL, Field, action
 from py4web.utils.mailer import Mailer
 from py4web.utils.auth import Auth
 from py4web.utils.downloader import downloader
-from py4web.utils.tags import Tags
+from pydal.tools.tags import Tags
 from py4web.utils.factories import ActionFactory
 from . import settings
 


### PR DESCRIPTION
... instead of py4web.utils.tags following #590