### PR TITLE
formatting for button columns, join support, form show_id

### DIFF
--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -357,20 +357,21 @@ class FormStyleFactory:
             title = field._title if "_title" in field.__dict__ else None
             field_disabled = False
 
-            # only diplay field if readable or writable
+            # only display field if readable or writable
             if not field.readable and not field.writable:
                 continue
 
-            # if this is a reaonly field only show readable fields
+            # if this is a readonly field only show readable fields
             if readonly:
                 if not field.readable:
                     continue
 
-                # do not show the id if not desired
-                if field.type == "id" and not show_id:
-                    continue
+            # do not show the id if not desired
+            if field.type == "id" and not show_id:
+                continue
 
-            # if this is an create form (unkown id) then only show writable fields. Some if an edit form was made from a list of fields and noncreate=True
+            #  if this is an create form (unkown id) then only show writable fields.
+            #  Some if an edit form was made from a list of fields and noncreate=True
             elif not vars.get("id") and noncreate:
                 if not field.writable:
                     continue

--- a/py4web/utils/grid.py
+++ b/py4web/utils/grid.py
@@ -489,9 +489,13 @@ class Grid:
                     for field in db[col.tablename]:
                         needed_fields.add(field)
             self.needed_fields = list(needed_fields)
-        else:
-            # the columns specify with fields are needed
-            self.needed_fields = self.param.columns[:]
+
+        # make sure the columns specified with fields are included
+        if self.param.columns:
+            for col in self.param.columns:
+                if not isinstance(col, (Column, FieldVirtual)):
+                    if col.longname not in [x.longname for x in self.needed_fields]:
+                        self.needed_fields.append(col)
 
         # except the primary key may be missing and must be fetched even if not displayed
         if not any(col.name == table._id.name for col in self.needed_fields):

--- a/py4web/utils/grid.py
+++ b/py4web/utils/grid.py
@@ -639,8 +639,6 @@ class Grid:
             self.param.columns.append(
                 Column("", self.make_action_buttons, td_class_style="grid-td-buttons")
             )
-        else:
-            redirect(self.endpoint)
 
     def iter_pages(
         self,

--- a/py4web/utils/grid.py
+++ b/py4web/utils/grid.py
@@ -243,9 +243,10 @@ class GridClassStyleBulma(GridClassStyle):
 class Column:
     """class used to represent a column in a grid"""
 
-    def __init__(self, name, represent):
+    def __init__(self, name, represent, orderby=None):
         self.name = name
         self.represent = represent
+        self.orderby = orderby
 
     def render(self, row, index=None):
         """renders a row al position index (optional)"""
@@ -253,8 +254,8 @@ class Column:
 
 
 class ButtonsColumn(Column):
-    def __init__(self, name, represent, position="pre"):
-        Column.__init__(self, name, represent)
+    def __init__(self, name, represent, orderby=None, position="pre"):
+        Column.__init__(self, name, represent, orderby)
         self.position = position
 
     pass
@@ -824,6 +825,8 @@ class Grid:
             elif isinstance(column, Column):
                 key = column.name.lower().replace(" ", "-")
                 col = column.name
+                if column.orderby:
+                    key, col = self._make_field_header(column, index, sort_order)
             else:
                 raise RuntimeError("Invalid Grid Column type")
             if col is not None:
@@ -840,11 +843,17 @@ class Grid:
         up = I(**self.param.grid_class_style.get("grid-sorter-icon-up"))
         dw = I(**self.param.grid_class_style.get("grid-sorter-icon-down"))
 
-        key = "%s.%s" % (field.tablename, field.name)
+        if isinstance(field, Column):
+            key = str(field.orderby)
+        else:
+            key = "%s.%s" % (field.tablename, field.name)
+
         heading = (
             self.param.headings[field_index]
             if field_index < len(self.param.headings)
             else field.label
+            if "label" in field.__dict__
+            else field.name
         )
         heading = title(heading)
         #  add the sort order query parm

--- a/py4web/utils/grid.py
+++ b/py4web/utils/grid.py
@@ -489,6 +489,8 @@ class Grid:
                     for field in db[col.tablename]:
                         needed_fields.add(field)
             self.needed_fields = list(needed_fields)
+        else:
+            self.needed_fields = self.param.columns[:]
 
         # make sure the columns specified with fields are included
         if self.param.columns:

--- a/py4web/utils/grid.py
+++ b/py4web/utils/grid.py
@@ -70,6 +70,8 @@ class GridClassStyle:
         "grid-tr": "",
         "grid-th": "",
         "grid-td": "",
+        "grid-td-buttons": "",
+        "grid-button": "info",
         "grid-details-button": "grid-details-button info",
         "grid-edit-button": "grid-edit-button info",
         "grid-delete-button": "grid-delete-button info",
@@ -91,6 +93,7 @@ class GridClassStyle:
         "grid-cell-type-datetime": "grid-cell-type-datetime",
         "grid-cell-type-upload": "grid-cell-type-upload",
         "grid-cell-type-list": "grid-cell-type-list",
+        "grid-cell-type-id": "grid-cell-type-id",
         # specific for custom form
         "grid-search-form": "grid-search-form",
         "grid-search-form-table": "grid-search-form-table",
@@ -108,9 +111,12 @@ class GridClassStyle:
         "grid-table": "",
         "grid-sorter-icon-up": "",
         "grid-sorter-icon-down": "",
+        "grid-thead": "",
         "grid-tr": "",
         "grid-th": "white-space: nowrap; vertical-align: middle;",
         "grid-td": "white-space: nowrap; vertical-align: middle;",
+        "grid-td-buttons": "",
+        "grid-button": "margin-bottom: 0;",
         "grid-details-button": "margin-bottom: 0;",
         "grid-edit-button": "margin-bottom: 0;",
         "grid-delete-button": "margin-bottom: 0;",
@@ -132,6 +138,7 @@ class GridClassStyle:
         "grid-cell-type-datetime": "white-space: nowrap; vertical-align: middle; text-align: right;",
         "grid-cell-type-upload": "white-space: nowrap; vertical-align: middle; text-align: center;",
         "grid-cell-type-list": "white-space: nowrap; vertical-align: middle; text-align: left;",
+        "grid-cell-type-int": "white-space: nowrap; vertical-align: middle; text-align: right;",
         # specific for custom form
         "grid-search-form": "",
         "grid-search-form-table": "",
@@ -165,8 +172,8 @@ class GridClassStyleBulma(GridClassStyle):
         "grid-tr": "",
         "grid-th": "",
         "grid-td": "is-small",
-        "grid-td-buttons": "is-narrow",
-        "grid-button": "grid-button button",
+        "grid-td-buttons": "is-small is-narrow",
+        "grid-button": "grid-button button is-small",
         "grid-details-button": "grid-details-button button is-small",
         "grid-edit-button": "grid-edit-button button is-small",
         "grid-delete-button": "grid-delete-button button is-small",
@@ -188,6 +195,7 @@ class GridClassStyleBulma(GridClassStyle):
         "grid-cell-type-datetime": "grid-cell-type-datetime",
         "grid-cell-type-upload": "grid-cell-type-upload",
         "grid-cell-type-list": "grid-cell-type-list",
+        "grid-cell-type-id": "grid-cell-type-id has-text-centered",
         # specific for custom form
         "grid-search-form": "grid-search-form is-pulled-right pb-2",
         "grid-search-form-table": "grid-search-form-table",
@@ -205,9 +213,12 @@ class GridClassStyleBulma(GridClassStyle):
         "grid-table": "",
         "grid-sorter-icon-up": "",
         "grid-sorter-icon-down": "",
+        "grid-thead": "",
         "grid-tr": "",
         "grid-th": "text-align: center; text-transform: uppercase; vertical-align: bottom;",
         "grid-td": "",
+        "grid-td-buttons": "",
+        "grid-button": "",
         "grid-details-button": "",
         "grid-edit-button": "",
         "grid-delete-button": "",
@@ -224,13 +235,12 @@ class GridClassStyleBulma(GridClassStyle):
         "grid-cell-type-float": "vertical-align: top; text-align: right",
         "grid-cell-type-decimal": "vertical-align: top; text-align: right",
         "grid-cell-type-int": "vertical-align: top; text-align: center;",
-        "grid-cell-type-integer": "vertical-align: top; text-align: center;",
-        "grid-cell-type-reference": "vertical-align: top; text-align: center;",
         "grid-cell-type-date": "vertical-align: top; text-align: center;",
         "grid-cell-type-time": "vertical-align: top; text-align: center;",
         "grid-cell-type-datetime": "vertical-align: top; text-align: center;",
         "grid-cell-type-upload": "vertical-align: top; text-align: center;",
         "grid-cell-type-list": "vertical-align: top; text-align: left;",
+        "grid-cell-type-id": "",
         # specific for custom form
         "grid-search-form": "",
         "grid-search-form-table": "",
@@ -243,22 +253,22 @@ class GridClassStyleBulma(GridClassStyle):
 class Column:
     """class used to represent a column in a grid"""
 
-    def __init__(self, name, represent, orderby=None):
+    def __init__(
+        self,
+        name,
+        represent,
+        orderby=None,
+        td_class_style=None,
+    ):
         self.name = name
         self.represent = represent
         self.orderby = orderby
 
+        self.td_class_style = td_class_style
+
     def render(self, row, index=None):
         """renders a row al position index (optional)"""
         return self.represent(row)
-
-
-class ButtonsColumn(Column):
-    def __init__(self, name, represent, orderby=None, position="pre"):
-        Column.__init__(self, name, represent, orderby)
-        self.position = position
-
-    pass
 
 
 class Grid:
@@ -320,6 +330,8 @@ class Grid:
         editable=True,
         deletable=True,
         validation=None,
+        pre_action_buttons=None,
+        post_action_buttons=None,
         auto_process=True,
         rows_per_page=15,
         include_action_button_text=True,
@@ -349,6 +361,8 @@ class Grid:
         :param editable: URL to redirect to for editing records - set to False to not display the button
         :param deletable: URL to redirect to for deleting records - set to False to not display the button
         :param validation: optional validation function to pass to create and edit forms
+        :param pre_action_buttons: list of Column instances to include before the standard action buttons
+        :param post_action_buttons: list of Column instances to include after the standard action buttons
         :param auto_process: True/False - automatically process the sql for the form - if False, user is
                               responsible for calling process().
         :param T: optional pluralize object
@@ -376,6 +390,8 @@ class Grid:
             editable=editable,
             deletable=deletable,
             validation=validation,
+            pre_action_buttons=pre_action_buttons,
+            post_action_buttons=post_action_buttons,
             rows_per_page=rows_per_page,
             include_action_button_text=include_action_button_text,
             search_button_text=search_button_text,
@@ -614,7 +630,9 @@ class Grid:
                 self.number_of_pages += 1
 
         if self.param.details or self.param.editable or self.param.deletable:
-            self.param.columns.append(ButtonsColumn("", self.make_action_buttons))
+            self.param.columns.append(
+                Column("", self.make_action_buttons, td_class_style="grid-td-buttons")
+            )
         else:
             redirect(self.endpoint)
 
@@ -957,16 +975,14 @@ class Grid:
                     if field.readable and (field.type != "id" or self.param.show_id):
                         tr.append(self._make_field(row, field, index))
                 elif isinstance(column, Column):
-                    if isinstance(column, ButtonsColumn):
-                        classes = self.param.grid_class_style.classes.get(
-                            "grid-td-buttons"
-                        )
-                        style = self.param.grid_class_style.styles.get(
-                            "grid-td-buttons"
-                        )
-                    else:
-                        classes = self.param.grid_class_style.classes.get("grid-td")
-                        style = self.param.grid_class_style.styles.get("grid-td")
+                    classes = self.param.grid_class_style.classes.get(
+                        column.td_class_style,
+                        self.param.grid_class_style.classes.get("grid-td"),
+                    )
+                    style = self.param.grid_class_style.styles.get(
+                        column.td_class_style,
+                        self.param.grid_class_style.styles.get("grid-td"),
+                    )
                     tr.append(
                         TD(column.render(row, index), _class=classes, _style=style)
                     )
@@ -979,6 +995,19 @@ class Grid:
     def make_action_buttons(self, row):
         cat = CAT()
         row_id = row[self.param.field_id] if self.param.field_id else row.id
+
+        if self.param.pre_action_buttons and len(self.param.pre_action_buttons) > 0:
+            for btn in self.param.pre_action_buttons:
+                cat.append(
+                    self._make_action_button(
+                        url=btn.url,
+                        button_text=self.T(btn.text),
+                        icon=btn.icon,
+                        additional_classes=btn.additional_classes,
+                        message=btn.message,
+                        row_id=row_id if btn.append_id else None,
+                    )
+                )
 
         if self.param.details:
             if isinstance(self.param.details, str):
@@ -1030,6 +1059,20 @@ class Grid:
                     **attrs,
                 )
             )
+
+        if self.param.post_action_buttons and len(self.param.post_action_buttons) > 0:
+            for btn in self.param.post_action_buttons:
+                cat.append(
+                    self._make_action_button(
+                        url=btn.url,
+                        button_text=self.T(btn.text),
+                        icon=btn.icon,
+                        additional_classes=btn.additional_classes,
+                        message=btn.message,
+                        row_id=row_id if btn.append_id else None,
+                    )
+                )
+
         return cat
 
     def _make_table_pager(self):


### PR DESCRIPTION
Suggested fixes for a few issues I ran into:

1. The button column on the right needs special formatting for it to remain narrow, only taking the space it needs for the buttons. With bulma this is handled with the is-narrow class. To accommodate, I subclassed Column into ButtonsColumn so I could apply different formatting to the <td> for that column.  Not sure this is the implementation you want.
2. _make_action_buttons didn't work with joins because row.id doesn't know about joins and the self.param.field_id. I updated so it will use self.param.field_id if it contains a value, if not it defaults to row.id. In addition, self.param.field_id was not specified unless the user defined on instantiation. I updated the process() method to use the ID of the first table found if no field_id was supplied. QUESTION - is this the right behavior, or should we raise an error if left is specified without field_id?
3. show_id is being passed to the form.  The code to enforce this in form.py was indented one level where it shouldn't have been.

One more issue for discussion is how we handle pre/post action buttons.  It looks to me like if we specify a button as a Column that it will appear in its own column.  I feel it should go before or after (depending on how the dev wants it) the standard grid buttons in the same column.  Thoughts?  If you want, I can work on the implementation.