### PR TITLE
form updates fields not displayed on custom forms

### DIFF
--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -764,7 +764,10 @@ class Form(object):
                     uploaded_files = []
                     for field in self.table:
                         if field.writable and field.type != "id":
-                            original_value = post_vars.getall(field.name)
+                            if field.name in form_vars:
+                                original_value = post_vars.getall(field.name)
+                            else:
+                                continue
                             if isinstance(original_value, list):
                                 if len(original_value) == 1:
                                     original_value = original_value[0]


### PR DESCRIPTION
If you have a custom form and you have a writable field that is not included in the custom template, that field will be set to null when the form is updated.  

As a developer, I would expect that if the field isn't on the form that the database field would not be updated.  

This is a change to only update fields that appear on the form.