### PR TITLE
add hx-encoding. allow lamba function on pre/post action buttons

### DIFF
--- a/py4web/utils/grid.py
+++ b/py4web/utils/grid.py
@@ -1040,6 +1040,7 @@ class Grid:
                         additional_classes=btn.additional_classes,
                         message=btn.message,
                         row_id=row_id if btn.append_id else None,
+                        row=row,
                         ignore_attribute_plugin=btn.ignore_attribute_plugin
                         if "ignore_attribute_plugin" in btn.__dict__
                         else False,
@@ -1115,6 +1116,7 @@ class Grid:
                         additional_classes=btn.additional_classes,
                         message=btn.message,
                         row_id=row_id if btn.append_id else None,
+                        row=row,
                         ignore_attribute_plugin=btn.ignore_attribute_plugin
                         if "ignore_attribute_plugin" in btn.__dict__
                         else False,
@@ -1368,6 +1370,7 @@ class AttributesPluginHtmx(AttributesPlugin):
     def form(self, url):
         attrs = copy.copy(self.default_attrs)
         attrs["_hx-post"] = url
+        attrs["_hx-encoding"] = "multipart/form-data"
         return attrs
 
     def link(self, url):


### PR DESCRIPTION
1. add hx-encoding on all forms using the AttributesPluginHtmx so that upload fields will work
2. fix lambda functions on pre/post action buttons - I missed this in the major grid update a few weeks back