### PR TITLE
 allow removing extra auth_user fields from register and profile pages

### DIFF
--- a/py4web/utils/auth.py
+++ b/py4web/utils/auth.py
@@ -199,6 +199,7 @@ class Auth(Fixture):
             button_classes=copy.deepcopy(self.BUTTON_CLASSES),
             default_login_enabled=True,
             exclude_extra_fields_in_register=None,
+            exclude_extra_fields_in_profile=None,
         )
 
         """Creates and Auth object responsible for handling
@@ -1296,6 +1297,12 @@ class DefaultAuthForms:
             self.auth.db.auth_user.username.writable = False
         else:
             self.auth.db.auth_user.email.writable = False
+        if self.auth.param.exclude_extra_fields_in_profile:
+            for field in self.auth.extra_auth_user_fields:
+                if field.name in self.auth.param.exclude_extra_fields_in_profile:
+                    field.writable = False
+                    field.readable = False
+
         form = Form(
             self.auth.db.auth_user,
             user,

--- a/py4web/utils/auth.py
+++ b/py4web/utils/auth.py
@@ -198,6 +198,7 @@ class Auth(Fixture):
             messages=copy.deepcopy(self.MESSAGES),
             button_classes=copy.deepcopy(self.BUTTON_CLASSES),
             default_login_enabled=True,
+            exclude_extra_fields_in_register=None,
         )
 
         """Creates and Auth object responsible for handling
@@ -782,7 +783,6 @@ class Auth(Fixture):
             for group in self.param.messages.values():
                 for key, value in group.items():
                     group[key] = T(value)
-        
 
         def allowed(name):
             return set(self.param.allowed_actions) & set(["all", name])
@@ -1039,6 +1039,12 @@ class DefaultAuthForms:
     def register(self):
         self.auth.db.auth_user.password.writable = True
         fields = [field for field in self.auth.db.auth_user if field.writable]
+        if self.auth.param.exclude_extra_fields_in_register:
+            fields = [
+                field
+                for field in fields
+                if field.name not in self.auth.param.exclude_extra_fields_in_register
+            ]
         for k, field in enumerate(fields):
             if field.type == "password":
                 fields.insert(


### PR DESCRIPTION
If you add fields to auth_user using extra_auth_user_fields you sometimes don't want them all displayed on the auth/register page.  This PR allows you to specify:

`auth.param.exclude_extra_fields_in_register = [list_of_fields_to_exclude]
auth.param.exclude_extra_fields_in_profile = [list_of_fields_to_exclude]`

to exclude fields from the register and profile pags.

My use case is that I have fields to keep track of some additional things in auth_user that I don't want the user to be able to maintain in register or profile pages.