### PR TITLE
Allow search to work in the Grid with htmx

### DIFF
--- a/py4web/utils/grid.py
+++ b/py4web/utils/grid.py
@@ -770,7 +770,7 @@ class Grid:
             for key in request.query
             if not key in ("search_type", "search_string")
         ]
-        attrs = self.attributes_plugin.form(url=self.endpoint)
+        attrs = self.attributes_plugin.link(url=self.endpoint)
         form = FORM(*hidden_fields, **attrs)
         select = SELECT(
             *options,


### PR DESCRIPTION
The built in search forms work with htmx when we change it to a get request versus a post request. This will mean that there is no issue with the default search grid being used with HTMX.