### PR TITLE
Fixture (and Session, Flash) fix: add `_safe_local`-property which is thread safe and reset on every request

### DIFF
--- a/.github/workflows/run_test.yaml
+++ b/.github/workflows/run_test.yaml
@@ -1,6 +1,12 @@
-name: ombott-test
+name: master-test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
   build:

--- a/py4web/__init__.py
+++ b/py4web/__init__.py
@@ -27,7 +27,6 @@ from .core import (
     Translator,  # from pluralize
     Session,
     Cache,
-    Current,
     Flash,
     user_in,  # additional fixtures
     URL,  # custom helper

--- a/py4web/utils/auth.py
+++ b/py4web/utils/auth.py
@@ -969,15 +969,11 @@ class AuthAPI:
         # check the new_password2 only if passed
         if request.json is None:
             return auth._error("no json post payload")
-        res = auth.reset_password(
+        return auth.reset_password(
             request.json.get("token"),
             request.json.get("new_password"),
             request.json.get("new_password2", request.json.get("new_password")),
         )
-        if res:
-            return res
-        else:
-            return auth._error("invalid token, request expired")
 
     @staticmethod
     @api_wrapper

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -29,7 +29,7 @@ action.app_name = "tests"
 def index():
     db.thing.insert(name="test")
     session["number"] = session.get("number", 0) + 1
-    
+
     # test copying Field ThreadSafe attr
     db.thing.name.default = "test_clone"
     field_clone = copy.copy(db.thing.name)
@@ -65,6 +65,7 @@ class CacheAction(unittest.TestCase):
 
     def test_local(self):
         # for test coverage
+        Session.__init_request_ctx__()  # mimic before_request-hook
         index()
 
     def test_error_page(self):

--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -1,0 +1,72 @@
+from types import SimpleNamespace
+import pytest
+import threading
+from py4web.core import Fixture
+
+result = {'seq': []}
+
+
+def run_thread(func, *a):
+    t = threading.Thread(target=func, args=a)
+    return t
+
+
+class Foo(Fixture):
+    def on_request(self):
+        self._safe_local = SimpleNamespace()
+
+    @property
+    def bar(self):
+        return self._safe_local.a
+
+    @bar.setter
+    def bar(self, a):
+        self._safe_local.a = a
+
+
+foo = Foo()
+
+
+def before_request():
+    Fixture.__init_request_ctx__()
+
+
+@pytest.fixture
+def init_foo():
+    def init(key, a, evnt_done=None, evnt_play=None):
+        result['seq'].append(key)
+        before_request()
+        foo.on_request()
+        foo.bar = a
+        evnt_done and evnt_done.set()
+        evnt_play and evnt_play.wait()
+        result[key] = foo.bar
+        return foo
+    return init
+
+
+def test_fixtute_local_storage(init_foo):
+    assert init_foo('t1', 'a1') is foo
+    evnt_done = threading.Event()
+    evnt_play = threading.Event()
+    t2 = run_thread(init_foo, 't2', 'a2', evnt_done, evnt_play)
+    t3 = run_thread(init_foo, 't3', 'a3', None, None)
+    t2.start()
+    evnt_done.wait()
+    t3.start()
+    t3.join()
+    evnt_play.set()
+    t2.join()
+    assert foo.bar == 'a1'
+    assert result['t2'] == 'a2'
+    assert result['t3'] == 'a3'
+    assert ','.join(result['seq']) == 't1,t2,t3'
+
+
+def test_fixtute_error():
+    before_request()
+    # attempt to access _safe_local prop without on_request-call
+    with pytest.raises(RuntimeError) as err:
+        foo.bar
+    assert 'py4web hint' in err.value.args[0]
+    assert 'Foo object' in err.value.args[0]


### PR DESCRIPTION
Also this PR removes `Current`-fixture.
Reasons:
- it has the same issue as the Session - see #623 
- it is not used by `py4web.core` (there is `py4web.utils` which is better place for such things) 