### PR TITLE
PAM plugin updates + Auth changes

### DIFF
--- a/apps/_scaffold/common.py
+++ b/apps/_scaffold/common.py
@@ -82,12 +82,14 @@ auth = Auth(session, db, define_tables=False)
 auth.use_username = True
 auth.param.registration_requires_confirmation = settings.VERIFY_EMAIL
 auth.param.registration_requires_approval = settings.REQUIRES_APPROVAL
+auth.param.login_after_registration = settings.LOGIN_AFTER_REGISTRATION
 auth.param.allowed_actions = settings.ALLOWED_ACTIONS
 auth.param.login_expiration_time = 3600
 auth.param.password_complexity = {"entropy": 50}
 auth.param.block_previous_password_num = 3
 auth.param.default_login_enabled = settings.DEFAULT_LOGIN_ENABLED
 auth.define_tables()
+auth.fix_actions()
 
 # #######################################################
 # Configure email sender for auth

--- a/apps/_scaffold/controllers.py
+++ b/apps/_scaffold/controllers.py
@@ -34,4 +34,5 @@ from .common import db, session, T, cache, auth, logger, authenticated, unauthen
 def index():
     user = auth.get_user()
     message = T("Hello {first_name}".format(**user) if user else "Hello")
-    return dict(message=message)
+    actions = {"allowed_actions": auth.param.allowed_actions}
+    return dict(message=message, actions=actions)

--- a/apps/_scaffold/settings.py
+++ b/apps/_scaffold/settings.py
@@ -25,18 +25,23 @@ STATIC_FOLDER = required_folder(APP_FOLDER, "static")
 # location where to store uploaded files:
 UPLOAD_FOLDER = required_folder(APP_FOLDER, "uploads")
 
-# send email on regstration
+# send verification email on registration
 VERIFY_EMAIL = True
 
 # account requires to be approved ?
 REQUIRES_APPROVAL = False
 
-# ALLOWED_ACTIONS:
-# ["all"] 
-# ["login", "logout", "request_reset_password", "reset_password", "change_password", "change_email", "update_profile"]
-# if you add "login", add also "logout"
-ALLOWED_ACTIONS = ["all"]
+# auto login after registration
+# requires False VERIFY_EMAIL & REQUIRES_APPROVAL 
+LOGIN_AFTER_REGISTRATION = False
 
+# ALLOWED_ACTIONS in API / default Forms:
+# ["all"] 
+# ["login", "logout", "request_reset_password", "reset_password", \
+#  "change_password", "change_email", "profile", "config", "register",
+#  "verify_email", "unsubscribe"]
+# Note: if you add "login", add also "logout"
+ALLOWED_ACTIONS = ["all"]
 
 # email settings
 SMTP_SSL = False

--- a/apps/_scaffold/templates/layout.html
+++ b/apps/_scaffold/templates/layout.html
@@ -31,7 +31,9 @@
             </a>
             <ul>
               <li><a href="[[=URL('auth/profile')]]">Edit Profile</a></li>
-              <li><a href="[[=URL('auth/change_password')]]">Change Password</a></li>
+              [[if 'change_password' in globals().get('actions',{}).get('allowed_actions',{}):]]
+                <li><a href="[[=URL('auth/change_password')]]">Change Password</a></li>
+              [[pass]]
               <li><a href="[[=URL('auth/logout')]]">Logout</a></li>
             </ul>
           </li>

--- a/py4web/utils/auth.py
+++ b/py4web/utils/auth.py
@@ -46,10 +46,9 @@ def b16d(text):
 
 
 class AuthEnforcer(Fixture):
-
-    """
-    Base fixtures that checks if a condition is met
-    if not redirects to a different pages or returns HTTP 403
+    """Base fixture that checks if a condition is met.
+    
+    If not it redirects to a different page or returns HTTP 403
     """
 
     def __init__(self, auth, condition=None):
@@ -61,10 +60,11 @@ class AuthEnforcer(Fixture):
         return self.auth.transform(output, shared_data)
 
     def abort_or_redirect(self, page, message=""):
+        """Return HTTP 403 if 'application/json' in HTTP_ACCEPT
+        and HTTP_JSON_REDIRECTS flag is not set in the request to 'on'.
+        Else redirects to page
         """
-        return HTTP 403 if 'application/json' in HTTP_ACCEPT and HTTP_JSON_REDIRECTS flag is not set in the request to 'on'
-        else redirects to page
-        """
+        
         if re.search(REGEX_APPJSON, request.headers.get("accept", "")) and (
             request.headers.get("json-redirects", "") != "on"
         ):
@@ -83,7 +83,7 @@ class AuthEnforcer(Fixture):
         )
 
     def on_request(self):
-        """check that we have a user in the session and
+        """Checks that we have a user in the session and
         the condition is met"""
         user = self.auth.session.get("user")
         if not user or not user.get("id"):
@@ -92,10 +92,13 @@ class AuthEnforcer(Fixture):
         activity = self.auth.session.get("recent_activity")
         time_now = calendar.timegm(time.gmtime())
         # enforce the optionl auth session expiration time
-        if self.auth.param.login_expiration_time and activity:
-            if time_now - activity > self.auth.param.login_expiration_time:
-                del self.auth.session["user"]
-                self.abort_or_redirect("login", "Login expired")
+        if (
+            self.auth.param.login_expiration_time
+            and activity
+            and time_now - activity > self.auth.param.login_expiration_time
+        ):
+            del self.auth.session["user"]
+            self.abort_or_redirect("login", "Login expired")
         # record the time of the latest activity for logged in user (with throttling)
         if not activity or time_now - activity > 6:
             self.auth.session["recent_activity"] = time_now
@@ -105,7 +108,8 @@ class AuthEnforcer(Fixture):
 
 
 class Auth(Fixture):
-
+    """The Auth object is responsible for handling
+    authentication and authorization"""
     MESSAGES = {
         "verify_email": {
             "subject": "Confirm email",
@@ -181,6 +185,7 @@ class Auth(Fixture):
         block_previous_password_num=None,
         allowed_actions=None,
         use_appname_in_redirects=None,
+        password_in_db=True,
     ):
 
         self.param = Param(
@@ -202,8 +207,6 @@ class Auth(Fixture):
             exclude_extra_fields_in_profile=None,
         )
 
-        """Creates and Auth object responsible for handling
-        authentication and authorization"""
         self.__prerequisites__ = []
         self.inject = inject
         if session:
@@ -212,14 +215,13 @@ class Auth(Fixture):
             self.__prerequisites__.append(db)
         self.flash = Flash()
         self.__prerequisites__.append(self.flash)
-
         self.onsuccess = {}
-
         self.db = db
         self.session = session
         self.sender = sender
         self.route = "auth"
         self.use_username = use_username  # if False, uses email only
+        self.password_in_db = password_in_db # if False, password is never saved in db
         self.use_phone_number = use_phone_number
         # The self._link variable is not thread safe (only intended for testing)
         self.extra_auth_user_fields = extra_fields or []
@@ -228,13 +230,48 @@ class Auth(Fixture):
             self.define_tables()
         self.plugins = {}
         self.form_source = DefaultAuthForms(self)
+        self.fix_actions()
 
     def allows(self, action_name):
+        """Checks if the provided action is allowed on the Auth object"""
         return (
             "all" in self.param.allowed_actions
             or action_name in self.param.allowed_actions
         )
 
+    def fix_actions(self):
+        """Cleanup duplicated and expand 'all' allowed_actions on API and Forms"""
+        ALL_ALLOWED_ACTIONS = AuthAPI.public_api + AuthAPI.private_api + \
+                DefaultAuthForms.public_forms + DefaultAuthForms.private_forms + \
+                DefaultAuthForms.no_forms
+        #"login", 
+        #"logout", 
+        #"request_reset_password", 
+        #"reset_password", 
+        #"change_password", 
+        #"change_email", 
+        #"profile", 
+        #"config",
+        #"register",
+        #"verify_email",
+        #"unsubscribe",
+    
+        if "all" in self.param.allowed_actions:
+            self.param.allowed_actions = ALL_ALLOWED_ACTIONS
+        else:
+            # remove duplicates and unknown actions
+            self.param.allowed_actions = list(set(self.param.allowed_actions))
+            for unknown in self.param.allowed_actions:
+                if unknown not in ALL_ALLOWED_ACTIONS:
+                    self.param.allowed_actions.remove(unkown)
+
+    def deny_action(self, action_name):
+        """Deny the provided action on the Auth object"""
+
+        self.fix_actions()
+        if action_name in self.param.allowed_actions:
+            self.param.allowed_actions.remove(action_name)
+        
     def transform(self, output, shared_data):
         if self.inject:
             template_context = shared_data.get("template_context")
@@ -244,7 +281,7 @@ class Auth(Fixture):
     def define_tables(self):
         """Defines the auth_user table"""
         db = self.db
-        if not "auth_user" in db.tables:
+        if "auth_user" not in db.tables:
             ne = IS_NOT_EMPTY()
             if self.param.password_complexity:
                 requires = [IS_STRONG(**self.param.password_complexity), CRYPT()]
@@ -381,12 +418,15 @@ class Auth(Fixture):
 
     # utilities
     def get_user(self, safe=True):
-        """extracts the user form the session.
-        returns {} if no user in the session.
+        """Extracts the user from the session.
+
+        Returns {} if no user in the session.
         If session contains only a user['id']
-        retrives the other readable user info from auth_user"""
+        retrives the other readable user info from auth_user
+        """
+        
         user = self.session.get("user")
-        if not user or not isinstance(user, dict) or not "id" in user:
+        if not user or not isinstance(user, dict) or "id" not in user:
             return {}
         if len(user) == 1 and self.db:
             user = self.db.auth_user(user["id"])
@@ -414,8 +454,13 @@ class Auth(Fixture):
         return self.get_user()
 
     def register_plugin(self, plugin):
-        """registers an Auth plugin"""
+        """Registers an Auth plugin, usually from common.py inside apps"""
         self.plugins[plugin.name] = plugin
+        # special parameters values depending on the plugins
+        if plugin.name in ["pam", "ldap"]:
+            self.password_in_db = False
+            self.deny_action("change_password")
+            self.deny_action("request_reset_password")
 
     def store_user_in_session(self, user_id):
         self.session["user"] = {"id": user_id}
@@ -425,6 +470,8 @@ class Auth(Fixture):
     # Methods that do not assume a user
 
     def register(self, fields, send=True, next="", validate=True, route=None):
+        """Registers a new user after the user's parameters are entered
+        in the SignUp form"""
         if self.use_username:
             fields["username"] = fields.get("username", "").lower()
         fields["email"] = fields.get("email", "").lower()
@@ -459,10 +506,13 @@ class Auth(Fixture):
                 self.store_user_in_session(res["id"])
         return res
 
+
     def login(self, email, password):
+        """Login a new user after the user's parameters are entered
+        in the Login form"""
         db = self.db
 
-        # Default incase they are None or an error will occur.
+        # Default email and password in case they are None or an error will occur.
         email = "" if email is None else email
         password = "" if password is None else password
 
@@ -485,18 +535,32 @@ class Auth(Fixture):
                 query = db.auth_user.email == value
             user = db(query).select().first()
             if not user:
-                return (None, "Invalid email")
+                if self.use_username:
+                    return (None, "Invalid username")    
+                else:
+                    return (None, "Invalid email")
             if (user.action_token or "").startswith("pending-registration:"):
                 return (None, "Registration is pending")
             if user.action_token == "account-blocked":
                 return (None, "Account is blocked")
             if user.action_token == "pending-approval":
                 return (None, "Account needs to be approved")
-            if CRYPT()(password)[0] == user.password:
-                return (user, None)
+            if "pam" in self.plugins or "ldap" in self.plugins:
+                plugin_name = "pam" if "pam" in self.plugins else "ldap"
+                check = self.plugins[plugin_name].check_credentials(user.username, password)
+                if check:
+                    return (user, None)
+            else:
+                if CRYPT()(password)[0] == user.password:
+                    return (user, None)
             return None, "Invalid Credentials"
 
+
     def request_reset_password(self, email, send=True, next="", route=None):
+        """Send a mail with token for changing user's password after the user's parameters are entered
+        in the request_reset_password form
+        """
+        
         db = self.db
         value = email.lower()
         if self.use_username:
@@ -508,7 +572,7 @@ class Auth(Fixture):
         else:
             query = db.auth_user.email == value
         user = db(query).select().first()
-        if user and not user.action_token == "account-blocked":
+        if user and user.action_token != "account-blocked":
             token = str(uuid.uuid4())
             if next:
                 token += "/" + b16e(next)
@@ -546,11 +610,9 @@ class Auth(Fixture):
         qset = db(db.auth_user.id == user["id"])
         value, error = db.auth_user.password.validate(new_password)
         if error:
-            res = {"errors": {"new_password": error}}
-        else:
-            qset.update(password=value)
-            res = {}
-        return res
+            return {"errors": {"new_password": error}}
+        qset.update(password=value)
+        return {}
 
     # Methods that assume a user
 
@@ -578,11 +640,10 @@ class Auth(Fixture):
                 ]
                 if any(new_pwd == old_pwd for old_pwd in past_pwds):
                     return {"errors": {"new_password": "new password was already used"}}
-                else:
-                    past_pwds.insert(0, user.get("password"))
-                    db(db.auth_user.id == user.get("id")).update(
-                        past_passwords_hash=past_pwds
-                    )
+                past_pwds.insert(0, user.get("password"))
+                db(db.auth_user.id == user.get("id")).update(
+                    past_passwords_hash=past_pwds
+                )
         num = db(db.auth_user.id == user.get("id")).update(
             password=new_pwd, last_password_change=datetime.datetime.utcnow()
         )
@@ -590,7 +651,7 @@ class Auth(Fixture):
 
     def change_email(self, user, new_email, password=None, check=True):
         db = self.db
-        if check and not CRYPT()(password)[0] == user.get("password"):
+        if check and CRYPT()(password)[0] != user.get("password"):
             return {"errors": {"password": "invalid"}}
         return (
             db(db.auth_user.id == user.get("id"))
@@ -705,8 +766,10 @@ class Auth(Fixture):
     # Other service methods (that can be overwritten)
 
     def send(self, name, user, **attrs):
-        """Extend the object and override this function to send messages with
-        twilio or onesignal or alternative method other than email"""
+        """Extends the object and override the function to send messages with
+        twilio or onesignal or alternative method other than email
+        """
+        
         message = self.param.messages[name]
         d = dict(user)
         d.update(**attrs)
@@ -772,7 +835,7 @@ class Auth(Fixture):
                 )
 
     def enable(self, route="auth", uses=(), env=None, spa=False):
-        """enables Auth, aka generates login/logout/register/etc pages"""
+        """Enables Auth, aka generates login/logout/register/etc API pages"""
         self.route = route = route.rstrip("/")
         env = env or {}
         auth = self
@@ -785,6 +848,7 @@ class Auth(Fixture):
                     group[key] = T(value)
 
         def allowed(name):
+            """Checks if an action is allowed"""
             return set(self.param.allowed_actions) & set(["all", name])
 
         methods = ["GET", "POST", "OPTIONS"]
@@ -864,6 +928,7 @@ class Auth(Fixture):
 
 
 def api_wrapper(func):
+    """Validates API calls"""
     def func_wrapper(auth, func=func):
         data = func(auth) or {}
         if not "status" in data and data.get("errors"):
@@ -878,7 +943,11 @@ def api_wrapper(func):
 
 
 class AuthAPI:
+    """AuthAPI class.
 
+    Defines all the public and private API methods
+    """
+    
     public_api = [
         "config",
         "register",
@@ -1020,6 +1089,7 @@ class AuthAPI:
 
 
 class DefaultAuthForms:
+    """Default Forms used for Auth actions"""
 
     public_forms = ["register", "login", "request_reset_password", "reset_password"]
     private_forms = ["profile", "change_password"]  # change_email, unsubscribe
@@ -1033,7 +1103,13 @@ class DefaultAuthForms:
         return self.auth.param.formstyle
 
     def register(self):
+        """SignUp form"""
         self.auth.db.auth_user.password.writable = True
+        if self.auth.password_in_db:
+            self.auth.db.auth_user.password.requires = [IS_STRONG(**self.auth.param.password_complexity), CRYPT()]
+        else:
+            self.auth.param.password_complexity={"entropy": 0}
+            self.auth.db.auth_user.password.requires = [IS_STRONG(**self.auth.param.password_complexity)]
         fields = [field for field in self.auth.db.auth_user if field.writable]
         if self.auth.param.exclude_extra_fields_in_register:
             fields = [
@@ -1042,7 +1118,7 @@ class DefaultAuthForms:
                 if field.name not in self.auth.param.exclude_extra_fields_in_register
             ]
         for k, field in enumerate(fields):
-            if field.type == "password":
+            if field.type == "password" and self.auth.password_in_db:
                 fields.insert(
                     k + 1,
                     Field(
@@ -1064,6 +1140,15 @@ class DefaultAuthForms:
         user = None
         if form.accepted:
             # notice that here the form is alrealdy validated
+            if not self.auth.password_in_db: # password must not be written in db
+                # Prioritize PAM or LDAP logins if enabled
+                if "pam" in self.auth.plugins or "ldap" in self.auth.plugins:
+                    plugin_name = "pam" if "pam" in self.auth.plugins else "ldap"
+                    check = self.auth.plugins[plugin_name].check_credentials(form.vars["username"], form.vars["password"])
+                    form.vars["password"]=""
+                    if not check:
+                        self._set_flash("Invalid username or password")
+                        redirect("register")
             res = self.auth.register(form.vars, validate=False)
             form.errors.update(**res.get("errors", {}))
             form.accepted = not form.errors
@@ -1092,7 +1177,7 @@ class DefaultAuthForms:
         return form
 
     def login_buttons(self):
-
+        """Define auth plugin type button to be displayed in login form"""
         top_buttons = []
 
         for name, plugin in self.auth.plugins.items():
@@ -1108,7 +1193,7 @@ class DefaultAuthForms:
         return top_buttons
 
     def login(self):
-
+        """Login form"""
         top_buttons = self.login_buttons()
 
         # if we do not allow we only display the plugin login buttons
@@ -1171,6 +1256,7 @@ class DefaultAuthForms:
         return form
 
     def request_reset_password(self):
+        """"Request reset password form"""
         form = Form(
             [
                 Field(
@@ -1207,6 +1293,7 @@ class DefaultAuthForms:
         return form
 
     def reset_password(self):
+        """Process reset password form"""
         user = None
         token = request.query.get("token")
         if token:
@@ -1239,6 +1326,7 @@ class DefaultAuthForms:
         return form
 
     def change_password(self):
+        """Request change password form"""
         user = self.auth.db.auth_user(self.auth.user_id)
         form = Form(
             [
@@ -1271,6 +1359,7 @@ class DefaultAuthForms:
         return form
 
     def _process_change_password_form(self, form, user, check_old_password):
+        """Process change password form"""
         if form.accepted:
             old_password = request.forms.get("old_password")
             new_password = request.forms.get("new_password")
@@ -1287,6 +1376,7 @@ class DefaultAuthForms:
                 form.vars.clear()
 
     def profile(self):
+        """Edit profile form"""
         user = self.auth.db.auth_user(self.auth.user_id)
         if "username" in self.auth.db.auth_user.fields:
             self.auth.db.auth_user.username.writable = False
@@ -1311,12 +1401,14 @@ class DefaultAuthForms:
         return form
 
     def logout(self):
+        """Process logout"""
         self.auth.session.clear()
         self._set_flash("user-logout")
         self._postprocessing("logout")
         return ""
 
     def verify_email(self):
+        """Process token in email verification"""
         token = request.query.get("token")
         verified = self.auth.verify_email(token)
         self._set_flash("email-verified" if verified else "link-expired")

--- a/py4web/utils/auth_plugins/pam.py
+++ b/py4web/utils/auth_plugins/pam.py
@@ -1,32 +1,33 @@
+# Modified 2013-2014 Leon Weber <leon@leonweber.de>:
+# See README.md for changelog
+#
+# Original author:
 # (c) 2007 Chris AtLee <chris@atlee.ca>
 # Licensed under the MIT license:
 # http://www.opensource.org/licenses/mit-license.php
 """
 PAM module for python
-
 Provides an authenticate function that will allow the caller to authenticate
 a user against the Pluggable Authentication Modules (PAM) on the system.
-
 Implemented using ctypes, so no compilation is necessary.
 """
-from __future__ import print_function
+__all__ = ['authenticate']
 
-__all__ = ["authenticate"]
-
-from ctypes import CDLL, POINTER, Structure, CFUNCTYPE, cast, pointer, sizeof
+from ctypes import CDLL, POINTER, Structure, CFUNCTYPE, cast, byref, sizeof
 from ctypes import c_void_p, c_uint, c_char_p, c_char, c_int
 from ctypes.util import find_library
+import sys
 
-LIBPAM = CDLL(find_library("pam"))
-LIBC = CDLL(find_library("c"))
+libpam = CDLL(find_library("pam"))
+libc = CDLL(find_library("c"))
 
-CALLOC = LIBC.calloc
-CALLOC.restype = c_void_p
-CALLOC.argtypes = [c_uint, c_uint]
+calloc = libc.calloc
+calloc.restype = c_void_p
+calloc.argtypes = [c_uint, c_uint]
 
-STRDUP = LIBC.strdup
-STRDUP.argstypes = [c_char_p]
-STRDUP.restype = POINTER(c_char)  # NOT c_char_p !!!!
+strdup = libc.strdup
+strdup.argstypes = [c_char_p]
+strdup.restype = POINTER(c_char)  # NOT c_char_p !!!!
 
 # Various constants
 PAM_PROMPT_ECHO_OFF = 1
@@ -34,11 +35,14 @@ PAM_PROMPT_ECHO_ON = 2
 PAM_ERROR_MSG = 3
 PAM_TEXT_INFO = 4
 
+PAM_REINITIALIZE_CRED = 0x0008  # This constant is libpam-specific.
+
 
 class PamHandle(Structure):
     """wrapper class for pam_handle_t"""
-
-    _fields_ = [("handle", c_void_p)]
+    _fields_ = [
+        ("handle", c_void_p)
+    ]
 
     def __init__(self):
         Structure.__init__(self)
@@ -47,7 +51,6 @@ class PamHandle(Structure):
 
 class PamMessage(Structure):
     """wrapper class for pam_message structure"""
-
     _fields_ = [
         ("msg_style", c_int),
         ("msg", c_char_p),
@@ -59,7 +62,6 @@ class PamMessage(Structure):
 
 class PamResponse(Structure):
     """wrapper class for pam_response structure"""
-
     _fields_ = [
         ("resp", c_char_p),
         ("resp_retcode", c_int),
@@ -68,66 +70,97 @@ class PamResponse(Structure):
     def __repr__(self):
         return "<PamResponse %i '%s'>" % (self.resp_retcode, self.resp)
 
-
-CONV_FUNC = CFUNCTYPE(
-    c_int, c_int, POINTER(POINTER(PamMessage)), POINTER(POINTER(PamResponse)), c_void_p
-)
+conv_func = CFUNCTYPE(c_int, c_int, POINTER(POINTER(PamMessage)),
+                      POINTER(POINTER(PamResponse)), c_void_p)
 
 
 class PamConv(Structure):
     """wrapper class for pam_conv structure"""
+    _fields_ = [
+        ("conv", conv_func),
+        ("appdata_ptr", c_void_p)
+    ]
 
-    _fields_ = [("conv", CONV_FUNC), ("appdata_ptr", c_void_p)]
+pam_start = libpam.pam_start
+pam_start.restype = c_int
+pam_start.argtypes = [c_char_p, c_char_p, POINTER(PamConv),
+                      POINTER(PamHandle)]
+
+pam_authenticate = libpam.pam_authenticate
+pam_authenticate.restype = c_int
+pam_authenticate.argtypes = [PamHandle, c_int]
+
+pam_setcred = libpam.pam_setcred
+pam_setcred.restype = c_int
+pam_setcred.argtypes = [PamHandle, c_int]
+
+pam_end = libpam.pam_end
+pam_end.restype = c_int
+pam_end.argtypes = [PamHandle, c_int]
 
 
-PAM_START = LIBPAM.pam_start
-PAM_START.restype = c_int
-PAM_START.argtypes = [c_char_p, c_char_p, POINTER(PamConv), POINTER(PamHandle)]
-
-PAM_AUTHENTICATE = LIBPAM.pam_authenticate
-PAM_AUTHENTICATE.restype = c_int
-PAM_AUTHENTICATE.argtypes = [PamHandle, c_int]
-
-
-def authenticate(username, password, service="login"):
+def authenticate(username, password, service='login', encoding='utf-8',
+                 resetcred=True):
     """Returns True if the given username and password authenticate for the
-    given service.  Returns False otherwise
-
+    given service.  Returns False otherwise.
     ``username``: the username to authenticate
-
     ``password``: the password in plain text
-
     ``service``: the PAM service to authenticate against.
-                 Defaults to 'login'"""
+                 Defaults to 'login'
+    The above parameters can be strings or bytes.  If they are strings,
+    they will be encoded using the encoding given by:
+    ``encoding``: the encoding to use for the above parameters if they
+                  are given as strings.  Defaults to 'utf-8'
+    ``resetcred``: Use the pam_setcred() function to
+                   reinitialize the credentials.
+                   Defaults to 'True'.
+    """
 
-    @CONV_FUNC
+    if sys.version_info >= (3,):
+        if isinstance(username, str):
+            username = username.encode(encoding)
+        if isinstance(password, str):
+            password = password.encode(encoding)
+        if isinstance(service, str):
+            service = service.encode(encoding)
+
+    @conv_func
     def my_conv(n_messages, messages, p_response, app_data):
         """Simple conversation function that responds to any
         prompt where the echo is off with the supplied password"""
         # Create an array of n_messages response objects
-        addr = CALLOC(n_messages, sizeof(PamResponse))
+        addr = calloc(n_messages, sizeof(PamResponse))
         p_response[0] = cast(addr, POINTER(PamResponse))
         for i in range(n_messages):
             if messages[i].contents.msg_style == PAM_PROMPT_ECHO_OFF:
-                pw_copy = STRDUP(str(password))
+                pw_copy = strdup(password)
                 p_response.contents[i].resp = cast(pw_copy, c_char_p)
                 p_response.contents[i].resp_retcode = 0
         return 0
 
     handle = PamHandle()
     conv = PamConv(my_conv, 0)
-    retval = PAM_START(service, username, pointer(conv), pointer(handle))
+    retval = pam_start(service, username, byref(conv), byref(handle))
 
     if retval != 0:
         # TODO: This is not an authentication error, something
         # has gone wrong starting up PAM
         return False
 
-    retval = PAM_AUTHENTICATE(handle, 0)
-    return retval == 0
+    retval = pam_authenticate(handle, 0)
+    auth_success = (retval == 0)
 
+    # Re-initialize credentials (for Kerberos users, etc)
+    # Don't check return code of pam_setcred(), it shouldn't matter
+    # if this fails
+    if auth_success and resetcred:
+        retval = pam_setcred(handle, PAM_REINITIALIZE_CRED)
+
+    pam_end(handle, retval)
+
+    return auth_success
 
 if __name__ == "__main__":
     import getpass
-
     print(authenticate(getpass.getuser(), getpass.getpass()))
+    


### PR DESCRIPTION
- PAM original plugin upgraded to simplepam (https://github.com/leonnnn/python3-simplepam) that supports Python3 - now it works fine
- better allowed_actions support, with values injected in forms and layout.html
- new auth.deny_action method
- new auth.password_in_db parameter, as a standard way to deal with external authentication
- new LOGIN_AFTER_REGISTRATION parameter in _scaffold/settings.py and common.py (closes #515)

Note: by design PAM authentication using local users works fine only if py4web is run by root. Otherwise you can only authenticate the single user that runs py4web.