### PR TITLE
Add filter_in/filter_out to threadsafe db Field parameters.

### DIFF
--- a/py4web/core.py
+++ b/py4web/core.py
@@ -376,6 +376,8 @@ def thread_safe_pydal_patch():
         "readable",
         "writable",
         "default",
+        "filter_in",
+        "filter_out",
         "label",
         "update",
         "requires",
@@ -1497,7 +1499,7 @@ def start_server(kwargs):
             server_config["server"] = "gunicorn"
 
     # Catch interrupts like Ctrl-C if needed
-    if server_config["server"] not in ("rocket","wsgirefWsTwistedServer" ):
+    if server_config["server"] not in ("rocket", "wsgirefWsTwistedServer"):
 
         signal.signal(
             signal.SIGINT,
@@ -1505,8 +1507,8 @@ def start_server(kwargs):
                 "KeyboardInterrupt (ID: {}) has been caught. Cleaning up...".format(
                     signal
                 )
-            and sys.exit(0),
-            )
+                and sys.exit(0),
+            ),
         )
 
     params["server"] = server_config["server"]


### PR DESCRIPTION
I have a field in a table that I encrypt with my own encryption scheme.  I can call my custom encrypt/decrypt routines using the filter_in/filter_out on the Field definition.  

I'd like to only allow decryption under certain circumstances so I don't want to set filter_in/filter_out in my model file, I prefer to do it in my controller only when I've confirmed that the user has the rights to view the unencrypted data.

Allowing the filter_in/filter_out as threadsafe variables accomplishes this.