### PR TITLE
allow callable for details/editable/deletable

### DIFF
--- a/py4web/utils/grid.py
+++ b/py4web/utils/grid.py
@@ -451,6 +451,11 @@ class Grid:
             return self.param.editable(row)
         return self.param.editable
 
+    def is_readable(self, row):
+        if callable(self.param.details):
+            return self.param.details(row)
+        return self.param.details
+
     def is_deletable(self, row):
         if callable(self.param.deletable):
             return self.param.deletable(row)
@@ -1058,7 +1063,7 @@ class Grid:
                     )
                 )
 
-        if self.param.details:
+        if self.is_readable(row):
             if isinstance(self.param.details, str):
                 details_url = self.param.details
             else:
@@ -1072,7 +1077,7 @@ class Grid:
                     name="grid-details-button",
                 )
             )
-        if self.param.editable:
+        if self.is_editable(row):
             if isinstance(self.param.editable, str):
                 edit_url = self.param.editable
             else:
@@ -1087,7 +1092,7 @@ class Grid:
                     _disabled=not self.is_editable(row),
                 )
             )
-        if self.param.deletable:
+        if self.is_deletable(row):
             if isinstance(self.param.deletable, str):
                 delete_url = self.param.deletable
             else:


### PR DESCRIPTION
This will dynamically show/hide the respective buttons based on a callable if one is passed.

Uses the is_editable/is_deletable methods that were already there and adds an is_readable as well.

is_deletable and is_editable seemed to be used to try to disable a button, but it did not disable the button. The button appeared disabled, but was still functional.  Now the button just disappears if not available the same as it would have if you'd passed False.

Comments welcome...