### PR TITLE
fix default in datetime display on forms

### DIFF
--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -87,7 +87,7 @@ class DateTimeWidget:
 
     def make(self, field, value, error, title, placeholder="", readonly=False):
         return INPUT(
-            _value=str(value).replace(" ", "T"),
+            _value=str(value).replace(" ", "T")[:16],
             _type=self.input_type,
             _id=to_id(field),
             _name=field.name,


### PR DESCRIPTION
It appears as though html5 <input type="datetime-local"> wants only a total of 16 characters sent to it.  It does not want the milliseconds.

This change puts the first 16 characters of the converted datetime into the value of the element.