### PR TITLE
Secure grid actions - update FormStyleBulma error message

### DIFF
--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -604,7 +604,7 @@ FormStyleBulma.classes.update(
         "inner": "control",
         "label": "label",
         "info": "help",
-        "error": "help is-danger py4web-validation-error",
+        "error": "help is-danger py4web-validation-error mt-1",
         "submit": "button is-primary",
         "input": "input",
         "input[type=text]": "input",

--- a/py4web/utils/grid.py
+++ b/py4web/utils/grid.py
@@ -7,6 +7,7 @@ import copy
 import datetime
 from urllib.parse import urlparse
 
+import ombott
 from pydal.objects import Field, FieldVirtual
 from yatl.helpers import (
     CAT,
@@ -446,6 +447,11 @@ class Grid:
         if auto_process:
             self.process()
 
+    def is_creatable(self):
+        if callable(self.param.create):
+            return self.param.create()
+        return self.param.create
+
     def is_editable(self, row):
         if callable(self.param.editable):
             return self.param.editable(row)
@@ -481,6 +487,7 @@ class Grid:
 
         parts = self.path.split("/")
         self.action = parts[0] or "select"
+
         if self.param.field_id:
             self.tablename = str(self.param.field_id._table)
         else:
@@ -540,6 +547,28 @@ class Grid:
         else:
             record = None
 
+        #  ensure the user has access for new/details/edit/delete if chosen
+        if self.action == "new" and not self.is_creatable():
+            ombott.abort(
+                code=403,
+                text=f"You do not have access to create a record in the {self.tablename} table.",
+            )
+        if self.action == "details" and not self.is_readable(record):
+            ombott.abort(
+                code=403,
+                text=f"You do not have access to read a record from the {self.tablename} table.",
+            )
+        if self.action == "edit" and not self.is_editable(record):
+            ombott.abort(
+                code=403,
+                text=f"You do not have access to edit a record in the {self.tablename} table.",
+            )
+        if self.action == "delete" and not self.is_deletable(record):
+            ombott.abort(
+                code=403,
+                text=f"You do not have access to delete a record in the {self.tablename} table.",
+            )
+
         if self.action in ["new", "details", "edit"]:
 
             readonly = self.action == "details"
@@ -560,7 +589,7 @@ class Grid:
                     self.form.param.sidecar.append(self.param.new_sidecar)
                 if self.param.new_submit_value:
                     self.form.param.submit_value = self.param.new_submit_value
-            if self.action == "details":
+            if self.action == "details" and self.is_readable(record):
                 if self.param.details_sidecar:
                     self.form.param.sidecar.append(self.param.details_sidecar)
                 if self.param.details_submit_value:


### PR DESCRIPTION
Prior to this commit a user could change the details/edit parameter in the URL and it wasn't re-checked to see if the user had access.  Ex
- user has access to the details action but not edit
- user clicks on Details button to display record
- user modifies the URL by changing details to edit - the user is allowed to edit the record - this should not be allowed

This PR checks access to an action again before the form is created

In addition it adds a class to FormStyleBulma to display error messages properly.