### PR TITLE
new simplified fixture logic

### DIFF
--- a/apps/_dashboard/__init__.py
+++ b/apps/_dashboard/__init__.py
@@ -87,7 +87,7 @@ class Logged(Fixture):
         self.__prerequisites__ = [session]
         self.session = session
 
-    def on_request(self):
+    def on_request(self, context):
         user = self.session.get("user")
         if not user or not user.get("id"):
             abort(403)

--- a/apps/examples/controllers.py
+++ b/apps/examples/controllers.py
@@ -45,7 +45,7 @@ def page_with_error():
 
 @action("page_with_raise")
 def page_with_raise():
-    raise HTTP(400)
+    raise HTTP(400, "oops")
 
 
 @action("page_with_redirect")

--- a/py4web/core.py
+++ b/py4web/core.py
@@ -341,32 +341,24 @@ class Fixture:
             )
             return False
 
-    def on_request(self):
+    def on_request(self, context):
         pass  # called when a request arrives
 
-    def on_error(self):
+    def on_error(self, context):
         pass  # called when a request errors
 
-    def on_success(self, status):
+    def on_success(self, context):
         pass  # called when a request is successful
-
-    def finalize(self):
-        pass  # called in any case at the end of a request
-
-    def transform(
-        self, output, shared_data=None
-    ):  # transforms the output, for example to apply template
-        return output
 
 
 _REQUEST_HOOKS.before.add(Fixture.__init_request_ctx__)
 
 
 class Translator(pluralize.Translator, Fixture):
-    def on_request(self):
+    def on_request(self, context):
         self.select(request.headers.get("Accept-Language", "en"))
 
-    def on_success(self, status):
+    def on_success(self, context):
         response.headers["Content-Language"] = self.local.tag
 
 
@@ -374,15 +366,15 @@ class DAL(pydal.DAL, Fixture):
 
     reconnect_on_request = True
 
-    def on_request(self):
+    def on_request(self, context):
         if self.reconnect_on_request:
             self._adapter.reconnect()
         threadsafevariable.ThreadSafeVariable.restore(ICECUBE)
 
-    def on_error(self):
+    def on_error(self, context):
         self.rollback()
 
-    def on_success(self, status):
+    def on_success(self, context):
         self.commit()
 
 
@@ -458,7 +450,7 @@ class Flash(Fixture):
     def local(self):
         return self._safe_local
 
-    def on_request(self):
+    def on_request(self, context):
         self._safe_local = types.SimpleNamespace()
         # when a new request arrives we look for a flash message in the cookie
         flash = request.get_cookie("py4web-flash")
@@ -467,14 +459,17 @@ class Flash(Fixture):
         else:
             self.local.flash = None
 
-    def on_success(self, status):
+    def on_success(self, context):
         # if we redirect and have a flash message we move it to the session
+        status = context["status"]
         if status == 303 and self.local.flash:
             response.set_cookie("py4web-flash", json.dumps(self.local.flash), path="/")
         else:
             response.delete_cookie("py4web-flash", path="/")
+        context["output"] = self.transform(context["output"])
+        self.local.__dict__.clear()
 
-    def finalize(self):
+    def on_error(self, context):
         """Clears the local to prevent leakage."""
         self.local.__dict__.clear()
 
@@ -484,7 +479,7 @@ class Flash(Fixture):
             message = yatl.sanitizer.xmlescape(message)
         self.local.flash = {"message": message, "class": _class}
 
-    def transform(self, data, shared_data=None):
+    def transform(self, data):
         # if we have a valid flash message, we inject it in the response dict
         if isinstance(data, dict):
             if "flash" not in data:
@@ -556,16 +551,16 @@ class Template(Fixture):
         self.path = path
         self.delimiters = delimiters
 
-    def transform(self, output, shared_data=None):
+    def on_success(self, context):
+        output = context["output"]
         if not isinstance(output, dict):
             return output
-        context = dict(request=request)
-        context.update(HELPERS)
-        context.update(URL=URL)
-        if shared_data:
-            context.update(shared_data.get("template_context", {}))
-        context.update(output)
-        context["__vars__"] = output
+        ctx = dict(request=request)
+        ctx.update(HELPERS)
+        ctx.update(URL=URL)
+        ctx.update(context.get('template_inject', {}))
+        ctx.update(output)
+        ctx["__vars__"] = output
         app_folder = os.path.join(os.environ["PY4WEB_APPS_FOLDER"], request.app_name)
         path = self.path or os.path.join(app_folder, "templates")
         filename = os.path.join(path, self.filename)
@@ -573,10 +568,9 @@ class Template(Fixture):
             generic_filename = os.path.join(path, "generic.html")
             if os.path.exists(generic_filename):
                 filename = generic_filename
-        output = render(
-            filename=filename, path=path, context=context, delimiters=self.delimiters
+        context["output"] = render(
+            filename=filename, path=path, context=ctx, delimiters=self.delimiters
         )
-        return output
 
 
 #########################################################################################
@@ -724,14 +718,14 @@ class Session(Fixture):
         self_local.data["uuid"] = str(uuid.uuid1())
         self_local.data["secure"] = self_local.secure
 
-    def on_request(self):
+    def on_request(self, context):
         self.load()
 
-    def on_error(self):
+    def on_error(self, context):
         if self.local.changed:
             self.save()
 
-    def on_success(self, status):
+    def on_success(self, context):
         if self.local.changed:
             self.save()
 
@@ -823,21 +817,17 @@ def URL(
 
 
 class HTTP(BaseException):
-    class Type:
-        success = "success"
-        error = "error"
 
-    """Our HTTP exception does not delete cookies and headers like the bottle.HTTPResponse does;
-    since it is considered a success, not a failure"""
+    """An exception that is considered success"""
 
-    def __init__(self, status, type=Type.success):
+    def __init__(self, status, body="", headers={}):
         self.status = status
-        self.type = type
+        self.body = body
+        self.headers = headers
 
 
 def redirect(location):
-    """our redirect does not delete cookies and headers like bottle.HTTPResponse does;
-    it is considered a success, not failure"""
+    """raises HTTP(303) to the specified location"""
     response.headers["Location"] = location
     raise HTTP(303)
 
@@ -872,44 +862,50 @@ class action:
 
             if Fixture.__fixture_debug__:
                 # in debug mode log all calls to fixtures
-                def call(obj, f, args=()):
-                    logging.debug("Calling %s.%s", obj.__class__.__name__, f)
-                    return getattr(obj, f)(*args)
+                def call(f, context):
+                    logging.debug(
+                        f"Calling {f.__self__.__class__.__name__}.{f.__name__}"
+                    )
+                    return f(context)
 
             else:
 
-                def call(obj, f, args=()):
-                    return getattr(obj, f)(*args)
+                def call(f, context):
+                    return f(context)
 
             @functools.wraps(func)
             def wrapper(*args, **kwargs):
                 # data shared by all fixtures in the pipeline for each request
-                shared_data = {"template_context": {}}
+                processed = []
+                context = {
+                    "fixtures": fixtures,
+                    "status": 200,
+                    "output": None,
+                    "exception": None,
+                    "processed": processed,
+                }
                 try:
-                    for obj in fixtures:
-                        call(obj, "on_request")
-                    ret = func(*args, **kwargs)
-                    for obj in fixtures:
-                        ret = call(obj, "transform", (ret, shared_data))
-                    for obj in fixtures:
-                        call(obj, "on_success", (200,))
-                    return ret
+                    for fixture in fixtures:
+                        call(fixture.on_request, context)
+                        processed.append(fixture)
+                    context["output"] = func(*args, **kwargs)
                 except HTTP as http:
-                    if http.type == http.Type.success:
-                        for obj in fixtures:
-                            call(obj, "on_success", (http.status,))
-                    else:
-                        if obj in fixtures:
-                            call(obj, "on_error")
-                    raise
-                except Exception:
-                    for obj in fixtures:
-                        call(obj, "on_error")
-                    raise
+                    context["status"] = http.status
+                    raise http
+                except Exception as error:
+                    context["exception"] = error
                 finally:
-                    for obj in fixtures:
-                        call(obj, "finalize")
-                    # Clears the current object to prevent leakage.
+                    for fixture in reversed(processed):
+                        try:
+                            if context.get('exception'):
+                                call(fixture.on_error, context)
+                            else:
+                                call(fixture.on_success, context)
+                        except Exception as error:
+                            context["exception"]= context.get("exception", error)
+                    if context["exception"]:
+                        raise context["exception"]
+                return context["output"]
 
             return wrapper
 
@@ -946,24 +942,17 @@ class action:
                 return ret
             except HTTP as http:
                 response.status = http.status
-                ret = getattr(http, "body", "")
-                http_headers = getattr(http, "headers", None)
-                if http_headers:
-                    response.headers.update(http_headers)
-                return ret
-            except bottle.HTTPResponse:
-                raise
+                response.headers.update(http.headers)
+                return http.body
             except Exception:
                 snapshot = get_error_snapshot()
                 logging.error(snapshot["traceback"])
                 ticket_uuid = error_logger.log(request.app_name, snapshot) or "unknown"
-                raise bottle.HTTPResponse(
-                    body=error_page(
-                        500,
-                        button_text=ticket_uuid,
-                        href="/_dashboard/ticket/" + ticket_uuid,
-                    ),
-                    status=500,
+                response.status = 500
+                response.body=error_page(
+                    500,
+                    button_text=ticket_uuid,
+                    href="/_dashboard/ticket/" + ticket_uuid,
                 )
 
         return wrapper

--- a/py4web/utils/auth.py
+++ b/py4web/utils/auth.py
@@ -9,7 +9,7 @@ import urllib
 import uuid
 
 from py4web import redirect, request, response, abort, URL, action, Field, HTTP
-from py4web.core import Fixture, Translator, Flash, REGEX_APPJSON
+from py4web.core import Fixture, Template, Translator, Flash, REGEX_APPJSON
 from py4web.utils.form import Form, FormStyleDefault
 from py4web.utils.param import Param
 from yatl.helpers import A, DIV
@@ -56,10 +56,8 @@ class AuthEnforcer(Fixture):
         self.auth = auth
         self.condition = condition
 
-    def transform(self, output, shared_data = None):
-        if shared_data is None:
-            shared_data = {}
-        return self.auth.transform(output, shared_data)
+    def on_success(self, context):
+        self.auth.on_success(context)
 
     def abort_or_redirect(self, page, message=""):
         """Return HTTP 403 if 'application/json' in HTTP_ACCEPT
@@ -84,7 +82,7 @@ class AuthEnforcer(Fixture):
             )
         )
 
-    def on_request(self):
+    def on_request(self, context):
         """Checks that we have a user in the session and
         the condition is met"""
         user = self.auth.session.get("user")
@@ -289,11 +287,9 @@ class Auth(Fixture):
         if action_name in self.param.allowed_actions:
             self.param.allowed_actions.remove(action_name)
         
-    def transform(self, output, shared_data = None):
+    def on_success(self, context):
         if self.inject:
-            template_context = shared_data.get("template_context")
-            template_context["user"] = self.get_user()
-        return output
+            context['template_inject'] = {'user': self.get_user()}
 
     def define_tables(self):
         """Defines the auth_user table"""

--- a/py4web/utils/cors.py
+++ b/py4web/utils/cors.py
@@ -17,7 +17,7 @@ class CORS(Fixture):
         self.headers = headers
         self.methods = methods
 
-    def on_request(self):
+    def on_request(self, context):
         response.headers["Access-Control-Allow-Origin"] = self.origin
         response.headers["Access-Control-Max-Age"] = self.age
         response.headers["Access-Control-Allow-Headers"] = self.headers

--- a/py4web/utils/factories.py
+++ b/py4web/utils/factories.py
@@ -12,10 +12,10 @@ class Inject(Fixture):
     def __init__(self, **variables):
         self.variables = variables
 
-    def transform(self, output, shared_data=None):
+    def on_success(self, context):
+        output = context['output']
         if isinstance(output, dict):
             output.update(**self.variables)
-        return output
 
 
 class ActionFactory:

--- a/py4web/utils/security.py
+++ b/py4web/utils/security.py
@@ -56,7 +56,7 @@ class CheckHeaders(Fixture):
             checked_parts.append(parts[3])
         return checked_parts
 
-    def on_request(self):
+    def on_request(self, context):
         print(request.environ["REMOTE_ADDR"])
         if self.protocol and not request.url.startswith(self.protocol + "://"):
             raise HTTP(400)
@@ -98,7 +98,7 @@ class AllowCors(Fixture):
         self.exposed_headers = ", ".join(exposed_headers)
         self.request_headers = ", ".join(request_headers)
 
-    def on_request(self):
+    def on_request(self, context):
         if self.origin:
             response.headers["Access-Control-Allow-Origin"] = self.origin
         if self.headers:

--- a/py4web/utils/url_signer.py
+++ b/py4web/utils/url_signer.py
@@ -20,7 +20,7 @@ class URLVerifier(Fixture):
             self.__prerequisites__ = [url_signer.session]
         self.url_signer = url_signer
 
-    def on_request(self):
+    def on_request(self, context):
         """Checks the request's signature"""
         # extra and remove the signature from the query
         signature = request.query.get("_signature")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -29,7 +29,7 @@ class TestAuth(unittest.TestCase):
         else:
             return getattr(self.auth.form_source, name)()
 
-    def on_request(self, keep_session=False):
+    def on_request(self, context={}, keep_session=False):
         storage = self.session._safe_local
 
         # mimic before_request bottle-hook
@@ -37,8 +37,8 @@ class TestAuth(unittest.TestCase):
 
         # mimic action.uses()
         self.session.initialize()
-        self.auth.flash.on_request()
-        self.auth.on_request()
+        self.auth.flash.on_request(context)
+        self.auth.on_request(context)
         if keep_session:
             self.session._safe_local = storage
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -8,5 +8,7 @@ PATH = os.path.join(os.path.dirname(__file__), "templates")
 class TemplateTest(unittest.TestCase):
     def test_template(self):
         t = Template("index.html", path=PATH)
-        output = t.transform(dict(n=3), {})
+        context = dict(output=dict(n=3))
+        t.on_success(context)
+        output = context['output']
         self.assertEqual(output, "0,1,2.\n")


### PR DESCRIPTION
Experimental branch. All tests passing.
This branch simplifies the syntax of fixtures while allowing more. New fixture have these methods only:

on_request(context)
on_success(context)
on_error(context)

context stores status, output, exception, fixtures, processed
This allowed every on_success to process the output depending on the status and on_error to eat or replace an exception and see what other fixtures were listed and which ones were processed while handling the exception.
