### PR TITLE
Added an example form with hCaptcha

### DIFF
--- a/apps/examples/common.py
+++ b/apps/examples/common.py
@@ -13,6 +13,9 @@ from pydal.tools.tags import Tags
 from py4web.utils.factories import ActionFactory
 from . import settings
 
+#used to validate hcapcha response
+import requests
+
 # #######################################################
 # implement custom loggers form settings.LOGGERS
 # #######################################################
@@ -199,3 +202,20 @@ auth.enable(uses=(session, T, db), env=dict(T=T))
 # #######################################################
 unauthenticated = ActionFactory(db, session, T, flash, auth)
 authenticated = ActionFactory(db, session, T, flash, auth.user)
+
+
+def hCaptcha(token):
+    
+    # Retrieve token from post data with key 'h-captcha-response'.
+
+    # Build payload with secret key and token.
+    data = { 'secret': settings.HCAPTCHA_SECRET_KEY, 'response': token }
+
+    # Make POST request with data payload to hCaptcha API endpoint.
+    response = requests.post(url=settings.HCAPTCHA_VERIFY_URL, data=data)
+
+    # Parse JSON from response. Check for success or error codes.
+    response_json = response.json()
+    success = response_json['success']
+
+    return success

--- a/apps/examples/controllers.py
+++ b/apps/examples/controllers.py
@@ -7,11 +7,11 @@ from py4web.utils.grid import Grid, GridClassStyle, Column
 from py4web.utils.param import Param
 from py4web.utils.publisher import Publisher, ALLOW_ALL_POLICY
 from pydal.validators import IS_NOT_EMPTY, IS_INT_IN_RANGE, IS_IN_SET, IS_IN_DB
-from yatl.helpers import INPUT, H1, HTML, BODY, A, DIV
+from yatl.helpers import INPUT, H1, HTML, BODY, A, DIV, XML
 from py4web.utils.param import Param
 from .settings import SESSION_SECRET_KEY
 
-from .common import db, session, T, flash, cache, authenticated, unauthenticated, auth
+from .common import db, session, T, flash, cache, authenticated, unauthenticated, auth, hCaptcha
 
 # import websocket examples
 from .ws import *
@@ -335,3 +335,22 @@ def mycomponent():
 @action.uses(flash, "component_loader.html")
 def component_loader():
     return dict()
+
+@unauthenticated("hcaptcha_form", "hcaptcha_form.html")
+def hcaptcha_form():
+    
+    form = Form([
+        Field('dummy_form', 'string',)
+    ])
+    
+    form.structure.append(XML('<div class="h-captcha" data-sitekey="762fa531-efd3-401d-9c3e-8f249e929f9c"></div>'))
+    if form.accepted:
+        r = hCaptcha(request.forms.get('g-recaptcha-response'))
+        if r == True:
+            #do something with form data
+            form.structure.append(XML('<div style="color:green">Captcha was solved succesfully!</font></div>'))
+        else:
+            form.structure.append(XML('<div class="py4web-validation-error">invalid captcha</div>'))
+            
+            
+    return dict(form=form)

--- a/apps/examples/controllers.py
+++ b/apps/examples/controllers.py
@@ -9,7 +9,7 @@ from py4web.utils.publisher import Publisher, ALLOW_ALL_POLICY
 from pydal.validators import IS_NOT_EMPTY, IS_INT_IN_RANGE, IS_IN_SET, IS_IN_DB
 from yatl.helpers import INPUT, H1, HTML, BODY, A, DIV, XML
 from py4web.utils.param import Param
-from .settings import SESSION_SECRET_KEY
+from .settings import SESSION_SECRET_KEY, HCAPTCHA_SITE_KEY
 
 from .common import db, session, T, flash, cache, authenticated, unauthenticated, auth, hCaptcha
 
@@ -343,7 +343,7 @@ def hcaptcha_form():
         Field('dummy_form', 'string',)
     ])
     
-    form.structure.append(XML('<div class="h-captcha" data-sitekey="762fa531-efd3-401d-9c3e-8f249e929f9c"></div>'))
+    form.structure.append(XML('<div class="h-captcha" data-sitekey="{}"></div>'.format(HCAPTCHA_SITE_KEY)))
     if form.accepted:
         r = hCaptcha(request.forms.get('g-recaptcha-response'))
         if r == True:

--- a/apps/examples/settings.py
+++ b/apps/examples/settings.py
@@ -82,3 +82,8 @@ try:
     from .settings_private import *
 except:
     pass
+
+## hcaptcha config
+HCAPTCHA_SITE_KEY = ""
+HCAPTCHA_SECRET_KEY = ""
+HCAPTCHA_VERIFY_URL = "https://hcaptcha.com/siteverify"

--- a/apps/examples/templates/hcaptcha_form.html
+++ b/apps/examples/templates/hcaptcha_form.html
@@ -1,0 +1,12 @@
+[[extend 'layout.html']]
+
+<h2 class="title">Simple form with hCaptcha</h2>
+
+[[=form]]
+
+
+
+
+[[block page_scripts]]
+<script src="https://js.hcaptcha.com/1/api.js" async defer></script>
+[[end]]

--- a/apps/examples/templates/index.html
+++ b/apps/examples/templates/index.html
@@ -107,6 +107,11 @@
     <td><a role="button" href="[[=URL('tagsinput_form')]]">example</a></td>
   </tr>
   <tr>
+    <td>A page with form using hCaptcha</td>
+    <td><a role="button" href="[[=URL('hcaptcha_form')]]">example</a></td>
+  </tr>
+  <tr>
+  <tr>
     <th colspan="2" class="is-info">Grid (no vue.js)</th>
   </tr>
   <tr>


### PR DESCRIPTION
Added an example form with hCaptcha, hopefully someone else can turn it in a plugin and integrate with auth form

In settings.py you need to add your site-key and secret-key obtained form hCaptcha  web site.

Cheers.