### PR TITLE
Simpler Reloeder.ROUTES logic

### DIFF
--- a/apps/_dashboard/__init__.py
+++ b/apps/_dashboard/__init__.py
@@ -159,7 +159,11 @@ if MODE in ("demo", "readonly", "full"):
     @session_secured
     def routes():
         """Returns current registered routes"""
-        return {"payload": Reloader.ROUTES, "status": "success"}
+        sorted_routes = {
+            name: list(sorted(routes, key=lambda route: route["rule"]))
+            for name, routes in Reloader.ROUTES.items()
+        }
+        return {"payload": sorted_routes, "status": "success"}
 
     @action("apps")
     @session_secured

--- a/apps/_dashboard/templates/index.html
+++ b/apps/_dashboard/templates/index.html
@@ -58,7 +58,7 @@
                     <button v-on:click="gitlog(selected_app.name)"><i class="fas fa-list"></i> Gitlog {{selected_app.name}}</button>
                     <button v-on:click="reload(selected_app.name)"><i class="fas fa-sync-alt"></i> Reload {{selected_app.name}}</button>
                 </div>
-                <table v-if="routes.length">
+                <table v-if="routes[selected_app.name].length">
                     <thead>
                         <tr>
                             <th>Rule</th>
@@ -71,7 +71,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        <tr v-for="route in routes" v-if="route.filename.startsWith(selected_app.name+'/') || route.filename.startsWith(selected_app.name+'\\')">
+                        <tr v-for="route in routes[selected_app.name]">
                             <td><a v-bind:href="route.rule" target="_blank"><tt>{{route.rule}}</tt></a></td>
                             <td><tt>{{route.method}}</tt></td>
                             <td><a v-on:click="select_filename(route.filename)"><tt>{{route.filename}}</tt></a></td>

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -65,6 +65,7 @@ class CacheAction(unittest.TestCase):
 
     def test_local(self):
         # for test coverage
+        request.app_name = "example"
         Session.__init_request_ctx__()  # mimic before_request-hook
         index()
 


### PR DESCRIPTION
This PR simplifies the Reloader.ROUTES logic (requires a _dashboard upgrade) and solves the problem raised by @valq7711  about auth routes not appearing in the dashboard. Can you please help me test it?

Notice that py4web always loops over the apps and imports one at the time. When this happens it knows the app_names and stores all the routes in Reloader.ROUTES[app_name] = [] so it can display them in the dashboard and clear them when needed.

