### PR TITLE
Scaffold Index missing T usage & Profile Update Issue

### DIFF
--- a/apps/_scaffold/controllers.py
+++ b/apps/_scaffold/controllers.py
@@ -31,7 +31,7 @@ from .common import db, session, T, cache, auth, logger, authenticated, unauthen
 
 
 @action("index")
-@action.uses("index.html", auth)
+@action.uses("index.html", auth, T)
 def index():
     user = auth.get_user()
     message = T("Hello {first_name}".format(**user) if user else "Hello")

--- a/py4web/utils/auth.py
+++ b/py4web/utils/auth.py
@@ -1664,7 +1664,7 @@ class DefaultAuthForms:
                         deletable=deletable)
 
         form = Form(
-            fields,
+            self.auth.db.auth_user,
             user,
             formstyle=self.formstyle,
             deletable=deletable,


### PR DESCRIPTION
Scaffold index missing T usage, erroring when opened.

To recreate: Clone and run py4web locally > open the _scaffold/index route > error occurs due to missing T import.