### PR TITLE
Update chapter-05.rst

### DIFF
--- a/docs/chapter-05.rst
+++ b/docs/chapter-05.rst
@@ -172,7 +172,7 @@ A route wildcard can be defined as
 -  ``<name:filter>`` or
 -  ``<name:filter:config>``
 
-And these are possible filters (only ``re:`` has a config):
+And these are possible filters (only ``:re`` has a config):
 
 -  ``:int`` matches (signed) digits and converts the value to integer.
 -  ``:float`` similar to :int but for decimal numbers.


### PR DESCRIPTION
The filters `:int`, etc. all have the colon before the ASCII string. `re` can be followed by colon, but the filter name should be consistent with the rest.