### PR TITLE
print statement not available in a Py3 program

### DIFF
--- a/docs/chapter-07.rst
+++ b/docs/chapter-07.rst
@@ -124,7 +124,7 @@ Row
    .. code:: python
 
       for row in rows:
-          print row.myfield
+          print(row.myfield)
 
 Query
    is an object that represents a SQL “where” clause:
@@ -298,8 +298,7 @@ the database is running from localhost on its default port and is named
 Database              Connection string
 ====================  =======================================================
 **SQLite**            ``sqlite://storage.sqlite``
-**MySQL**             ``mysql://username:password@localhost/test?set_encoding
-                      =utf8mb4``
+**MySQL**             ``mysql://username:password@localhost/test?set_encoding=utf8mb4``
 **PostgreSQL**        ``postgres://username:password@localhost/test``
 **MSSQL (legacy)**    ``mssql://username:password@localhost/test``
 **MSSQL (>=2005)**    ``mssql3://username:password@localhost/test``


### PR DESCRIPTION
also removed newline in URI that caused unwanted space in HTML representation