### PR TITLE
add header and trailer elements

### DIFF
--- a/py4web/utils/grid.py
+++ b/py4web/utils/grid.py
@@ -101,6 +101,8 @@ class GridClassStyle:
         "grid-search-form-tr": "grid-search-form-tr",
         "grid-search-form-td": "grid-search-form-td",
         "grid-search-boolean": "grid-search-boolean",
+        "grid-header-element": "grid-header-element info",
+        "grid-footer-element": "grid-footer-element info",
     }
 
     styles = {
@@ -139,13 +141,14 @@ class GridClassStyle:
         "grid-cell-type-datetime": "white-space: nowrap; vertical-align: middle; text-align: right;",
         "grid-cell-type-upload": "white-space: nowrap; vertical-align: middle; text-align: center;",
         "grid-cell-type-list": "white-space: nowrap; vertical-align: middle; text-align: left;",
-        "grid-cell-type-int": "white-space: nowrap; vertical-align: middle; text-align: right;",
         # specific for custom form
         "grid-search-form": "",
         "grid-search-form-table": "",
         "grid-search-form-tr": "border-bottom: none;",
         "grid-search-form-td": "",
         "grid-search-boolean": "",
+        "grid-header-element": "margin-top:4px; height:34px; line-height:34px;",
+        "grid-footer-element": "margin-top:4px; height:34px; line-height:34px;",
     }
 
     @classmethod
@@ -203,6 +206,8 @@ class GridClassStyleBulma(GridClassStyle):
         "grid-search-form-tr": "grid-search-form-tr",
         "grid-search-form-td": "grid-search-form-td pr-1",
         "grid-search-boolean": "grid-search-boolean",
+        "grid-header-element": "grid-header-element button",
+        "grid-footer-element": "grid-footer-element button",
     }
 
     styles = {
@@ -248,6 +253,8 @@ class GridClassStyleBulma(GridClassStyle):
         "grid-search-form-tr": "",
         "grid-search-form-td": "",
         "grid-search-boolean": "padding-top: .5rem;",
+        "grid-header-element": "",
+        "grid-footer-element": "",
     }
 
 
@@ -1246,7 +1253,9 @@ class Grid:
             )
         if self.param.header_elements and len(self.param.header_elements) > 0:
             for element in self.param.header_elements:
-                if callable(element):
+                if isinstance(element, str):
+                    html.append(XML(element))
+                elif callable(element):
                     grid_header.append(element())
                 else:
                     grid_header.append(
@@ -1258,10 +1267,10 @@ class Grid:
                             additional_classes=element.additional_classes,
                             message=element.message,
                             override_classes=self.param.grid_class_style.classes.get(
-                                "grid-new-button", ""
+                                "grid-header-element", ""
                             ),
                             override_styles=self.param.grid_class_style.styles.get(
-                                "grid-new-button"
+                                "grid-trailer-element"
                             ),
                         )
                     )
@@ -1309,7 +1318,9 @@ class Grid:
 
         if self.param.footer_elements and len(self.param.footer_elements) > 0:
             for element in self.param.footer_elements:
-                if callable(element):
+                if isinstance(element, str):
+                    html.append(XML(element))
+                elif callable(element):
                     html.append(element())
                 else:
                     html.append(
@@ -1321,10 +1332,10 @@ class Grid:
                             additional_classes=element.additional_classes,
                             message=element.message,
                             override_classes=self.param.grid_class_style.classes.get(
-                                "grid-new-button", ""
+                                "grid-footer-element", ""
                             ),
                             override_styles=self.param.grid_class_style.styles.get(
-                                "grid-new-button"
+                                "grid-footer-element"
                             ),
                         )
                     )

--- a/py4web/utils/grid.py
+++ b/py4web/utils/grid.py
@@ -9,8 +9,25 @@ from urllib.parse import urlparse
 
 import ombott
 from pydal.objects import Field, FieldVirtual
-from yatl.helpers import (CAT, DIV, FORM, INPUT, OPTION, SELECT, SPAN, TABLE,
-                          TAG, TBODY, TD, TH, THEAD, TR, XML, A, I)
+from yatl.helpers import (
+    CAT,
+    DIV,
+    FORM,
+    INPUT,
+    OPTION,
+    SELECT,
+    SPAN,
+    TABLE,
+    TAG,
+    TBODY,
+    TD,
+    TH,
+    THEAD,
+    TR,
+    XML,
+    A,
+    I,
+)
 
 from py4web import HTTP, URL, redirect, request
 from py4web.utils.form import Form, FormStyleDefault, join_classes
@@ -404,6 +421,8 @@ class Grid:
             edit_submit_value=None,
             edit_action_button_text="Edit",
             delete_action_button_text="Delete",
+            header_elements=None,
+            footer_elements=None,
         )
 
         #  instance variables that will be computed
@@ -1225,6 +1244,27 @@ class Grid:
                     ),
                 )
             )
+        if self.param.header_elements and len(self.param.header_elements) > 0:
+            for element in self.param.header_elements:
+                if callable(element):
+                    grid_header.append(element())
+                else:
+                    grid_header.append(
+                        self._make_action_button(
+                            url=element.url,
+                            button_text=self.T(element.text),
+                            icon=element.icon,
+                            icon_size="normal",
+                            additional_classes=element.additional_classes,
+                            message=element.message,
+                            override_classes=self.param.grid_class_style.classes.get(
+                                "grid-new-button", ""
+                            ),
+                            override_styles=self.param.grid_class_style.styles.get(
+                                "grid-new-button"
+                            ),
+                        )
+                    )
 
         #  build the search form if provided
         if self.param.search_form:
@@ -1266,6 +1306,29 @@ class Grid:
             footer.append(self._make_table_pager())
 
         html.append(footer)
+
+        if self.param.footer_elements and len(self.param.footer_elements) > 0:
+            for element in self.param.footer_elements:
+                if callable(element):
+                    html.append(element())
+                else:
+                    html.append(
+                        self._make_action_button(
+                            url=element.url,
+                            button_text=self.T(element.text),
+                            icon=element.icon,
+                            icon_size="normal",
+                            additional_classes=element.additional_classes,
+                            message=element.message,
+                            override_classes=self.param.grid_class_style.classes.get(
+                                "grid-new-button", ""
+                            ),
+                            override_styles=self.param.grid_class_style.styles.get(
+                                "grid-new-button"
+                            ),
+                        )
+                    )
+
         return html
 
     def render(self):


### PR DESCRIPTION
Allow user to specify additional html elements in above or below the grid.  The py4web grid doesn't allow for export as the web2py grid does.  With the addition of custom html elements above or below the grid, the user can build their own grid exporter functions and add buttons to the grid to call the functions.

Of course you're not limited to export functions.  You can specify any html element.  You can pass a callable or a GridActionButton-like class to build the html element.

header elements are added directly after the New button
footer elements are added on a new row below navigation footer
