### PR TITLE
fix nested divs in RadioWidget

### DIFF
--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -9,6 +9,7 @@ from pydal._compat import to_native
 from pydal.objects import FieldVirtual
 from pydal.validators import Validator
 from yatl.helpers import (
+    CAT,
     DIV,
     FORM,
     INPUT,
@@ -187,7 +188,7 @@ class SelectWidget:
 
 class RadioWidget:
     def make(self, field, value, error, title, placeholder="", readonly=False):
-        control = DIV()
+        control = CAT()
         field_id = to_id(field)
         value = list(map(str, value if isinstance(value, list) else [value]))
         field_options = [
@@ -460,9 +461,10 @@ class FormStyleFactory:
             if key == "input":
                 key += "[type=%s]" % (control["_type"] or "text")
 
-            control["_class"] = join_classes(
-                control.attributes.get("_class"), self.classes.get(key)
-            )
+            if hasattr(control, 'attributes'):
+                control["_class"] = join_classes(
+                    control.attributes.get("_class"), self.classes.get(key)
+                )
 
             # Set the form controls.
             controls["labels"][field_name] = field_label


### PR DESCRIPTION
The HTML generated by RadioWidget has a double nesting of divs,
label and input are grouped inside a div to be returned together.
I think it's better to return a cat to avoid double nesting.

Before:
```
<div class="field">
	<label class="label" for="form_colors_ff_colors">Color</label>
		<div class="control">
			<div class="">
				<input id="form_colors_ff_colorsBlue" label="Blue" name="ff_colors" type="radio" value="Blue">
				<label for="form_colors_ff_colorsBlue">Blue</label>
				<input id="form_colors_ff_colorsGreen" label="Green" name="ff_colors" type="radio" value="Green">
				<label for="form_colors_ff_colorsGreen">Green</label>
			</div>
		</div>
	<p class="help"></p>
</div>
```
After:
```
<div class="field">
	<label class="label" for="form_colors_ff_colors">Color</label>
		<div class="control">
			<input id="form_colors_ff_colorsBlue" label="Blue" name="ff_colors" type="radio" value="Blue">
			<label for="form_colors_ff_colorsBlue">Blue</label>
			<input id="form_colors_ff_colorsGreen" label="Green" name="ff_colors" type="radio" value="Green">
			<label for="form_colors_ff_colorsGreen">Green</label>
		</div>
	<p class="help"></p>
</div>
```