### PR TITLE
Proposed fix for gevent.

### DIFF
--- a/py4web/core.py
+++ b/py4web/core.py
@@ -1584,6 +1584,11 @@ def start_server(kwargs):
         params["keyfile"] = kwargs["ssl_key"]
 
     if server_config["server"] == "gevent":
+        if kwargs['watch'] != 'off':
+            print('Error: watch doesn\'t work with gevent. ')
+            print('invoke py4web with `--watch off` or choose another server. ')
+            exit(255)
+
         if not hasattr(_ssl, "sslwrap"):
             _ssl.sslwrap = new_sslwrap
 


### PR DESCRIPTION
 * aborts when gevent and any form of watch is enabled thus informing the user of what's wrong and what to do about it.
 * adds gevent to server_adapters.py, similar to ombotts version, but removes the reloader option which otherwise breaks the gevent wsgi server.