### PR TITLE
add two factor auth

### DIFF
--- a/py4web/utils/auth.py
+++ b/py4web/utils/auth.py
@@ -3,6 +3,7 @@ import calendar
 import copy
 import datetime
 import hashlib
+import random
 import re
 import time
 import urllib
@@ -158,6 +159,7 @@ class Auth(Fixture):
             "created_by": "Created By",
             "modified on": "Modified On",
             "modified by": "Modified By",
+            "two_factor": "Authentication Code",
         },
         "buttons": {
             "lost-password": "Lost Password",
@@ -181,6 +183,8 @@ class Auth(Fixture):
             "new_password_was_already_used": "new password was already used",
             "invalid": "invalid",
             "no_post_payload": "no post payload",
+            "two_factor": "Verification code does not match",
+            "two_factor_max_tries": "Two factor max tries exceeded",
         },
     }
 
@@ -211,6 +215,8 @@ class Auth(Fixture):
         allowed_actions=None,
         use_appname_in_redirects=None,
         password_in_db=True,
+        two_factor_filter=None,
+        two_factor_methods=None,
     ):
 
         # configuration parameters
@@ -232,6 +238,11 @@ class Auth(Fixture):
             exclude_extra_fields_in_register=None,
             exclude_extra_fields_in_profile=None,
             expose_all_models=True,
+            two_factor_filter=two_factor_filter,
+            two_factor_methods=[two_factor_methods]
+            if isinstance(two_factor_methods, str)
+            else two_factor_methods,
+            two_factor_tries=3,
         )
 
         # callbacks for forms
@@ -1315,7 +1326,13 @@ class AuthAPI:
 class DefaultAuthForms:
     """Default Forms used for Auth actions"""
 
-    public_forms = ["register", "login", "request_reset_password", "reset_password"]
+    public_forms = [
+        "register",
+        "login",
+        "request_reset_password",
+        "reset_password",
+        "two_factor",
+    ]
     private_forms = ["profile", "change_password"]  # change_email, unsubscribe
     no_forms = ["logout", "verify_email"]
 
@@ -1543,6 +1560,23 @@ class DefaultAuthForms:
             form.accepted = not error
             form.errors["email"] = error
         if user:
+            #  We will process two_factor if
+            #  - at least one two_factor_method is defined
+            #      AND
+            #  - Either
+            #      - No two_factor_filter defined
+            #          OR
+            #      - two_factor_filter returns True
+            #
+            #  if two_factor_filter exists and returns False, then this user bypasses two_factor processing
+            if self.auth.param.two_factor_methods:
+                if (
+                    not self.auth.param.two_factor_filter
+                    or self.auth.param.two_factor_filter(user, request)
+                ):
+                    self.auth.session["two_factor_user"] = user["id"]
+                    self.auth.session["two_factor_next_url"] = next_url
+                    redirect(URL("auth", "two_factor"))
             self.auth.store_user_in_session(user["id"])
             self._postprocessing("login", form, user)
 
@@ -1566,6 +1600,104 @@ class DefaultAuthForms:
             )
         form.structure.insert(0, DIV(top_buttons["combined_div"]))
         return form
+
+    def _reset_two_factor(self):
+        self.auth.session["two_factor_user"] = None
+        self.auth.session["two_factor_code"] = None
+        self.auth.session["two_factor_tries_left"] = self.auth.param.two_factor_tries
+
+    def two_factor(self):
+        two_factor_user = self.auth.session.get("two_factor_user")
+        next_url = self.auth.session.get("two_factor_next_url")
+
+        if two_factor_user:
+            user = self.auth.db.auth_user(two_factor_user)
+        else:
+            #  two_factor_user wasn't found so we're not coming from the login page.  Redirect home...
+            redirect(URL("index"))
+
+        form = Form(
+            [
+                Field(
+                    "authentication_code",
+                    label=self.auth.param.messages["labels"]["two_factor"],
+                    required=True,
+                ),
+                Field("next_url", label="", default=next_url),
+            ],
+            formstyle=self.auth.param.formstyle,
+            form_name="auth_2fa",
+            keep_values=True,
+            validation=lambda f: DefaultAuthForms._validate_two_factor(
+                f,
+                self.auth.session.get("two_factor_code"),
+                self.auth.param.messages["errors"],
+            ),
+        )
+
+        form.structure.find("[name=next_url]")[0]["_style"] = "display: none"
+
+        if form.accepted:
+            if form.vars.get("authentication_code") == str(
+                self.auth.session.get("two_factor_code")
+            ):
+                self._reset_two_factor()
+                self.auth.store_user_in_session(user["id"])
+                self._postprocessing("login", form, user)
+                redirect(next_url)
+            else:
+                self.auth.session["two_factor_tries_left"] -= 1
+
+                if self.auth.session.get("two_factor_tries_left") < 1:
+                    self._reset_two_factor()
+                    redirect(URL("auth", "login", vars=dict(next=next_url)))
+                    self._set_flash(
+                        self.auth.param.messages["errors"]["two_factor_max_tries"]
+                    )
+                else:
+                    self._set_flash(self.auth.param.messages["errors"]["two_factor"])
+                    form.errors["authentication_code"] = self.auth.param.messages[
+                        "errors"
+                    ]["two_factor"]
+                    form.accepted = False
+        else:
+            if not self.auth.session.get("two_factor_code"):
+                self.auth.session["two_factor_code"] = str(
+                    random.randint(100000, 999999)
+                )
+                self.auth.session[
+                    "two_factor_tries_left"
+                ] = self.auth.param.two_factor_tries
+
+                for two_factor_method in self.auth.param.two_factor_methods:
+                    try:
+                        # By default we use session.auth_two_factor generated before.
+                        self.auth.session["two_factor_code"] = str(
+                            two_factor_method(
+                                user,
+                                self.auth.session.get("two_factor_code"),
+                            )
+                        )
+                    except:
+                        pass
+                    else:
+                        break
+            if len(form.errors) > 0:
+                self.auth.session["two_factor_tries_left"] -= 1
+
+                if self.auth.session.get("two_factor_tries_left") < 1:
+                    self._reset_two_factor()
+                    self._set_flash(
+                        self.auth.param.messages["errors"]["two_factor_max_tries"]
+                    )
+                    redirect(URL("auth", "login", vars=dict(next=next_url)))
+
+        return form
+
+    @staticmethod
+    def _validate_two_factor(form, two_factor_code, error_messages):
+        if form.vars.get("authentication_code") != two_factor_code:
+            form.errors["authentication_code"] = error_messages["two_factor"]
 
     def request_reset_password(self, model=False):
         """ "Request reset password form"""


### PR DESCRIPTION
Add two factor authentication

docs chapter 13 updated to include documentation on how to use it.  @nicozanf - I only updated the source, I did not process all the changes.

In short, added 2 arguments to Auth()

two_factor_filter - allows you to decide which logins need two factor applied
two_factor_methods - specify methods to use to communicate two factor code to the user

Added messages for 2 factor label and a couple error messages

Added auth.param for two_factor_tries and defaulted to 3

For the processing, I added a new endpoint, auth/two_factor that generates the code, calls the two_factor_methods and displays the verification form.

Other thoughts
In web2py two_factor you can filter the two factor logins in a couple different ways, in py4web I didn't provide anything by default, but you can control with the two_factor_filter parm.  In addition, py4web provides a default notification via email.  I did not provide that, but showed an example in the docs.

Let me know  what I missed or if I'm way off base....