### PR TITLE
Grid updates - clean up action button implementation / redirect on successful delete

### DIFF
--- a/docs/chapter-14.rst
+++ b/docs/chapter-14.rst
@@ -417,25 +417,33 @@ Sample Action Button Class
 .. code:: python
 
    class GridActionButton:
-      def __init__(
-         self,
-         url,
-         text=None,
-         icon=None,
-         onclick=None,
-         additional_classes="",
-         message="",
-         append_id=False,
-         ignore_attribute_plugin=False,
-      ):
-         self.url = url
-         self.text = text
-         self.icon = icon
-         self.onclick = onclick
-         self.additional_classes = additional_classes
-         self.message = message
-         self.append_id = append_id
-         self.ignore_attribute_plugin = ignore_attribute_plugin
+    def __init__(
+        self,
+        url,
+        text=None,
+        icon=None,
+        additional_classes="",
+        additional_styles="",
+        override_classes="",
+        override_styles="",
+        message="",
+        append_id=False,
+        name=None,
+        ignore_attribute_plugin=False,
+        **attrs
+    ):
+        self.url = url
+        self.text = text
+        self.icon = icon
+        self.additional_classes = additional_classes
+        self.additional_styles = additional_styles
+        self.override_classes = override_classes
+        self.override_styles = override_styles
+        self.message = message
+        self.append_id = append_id
+        self.name = name
+        self.ignore_attribute_plugin = ignore_attribute_plugin
+        self.attrs = attrs
 
 -  url: the page to navigate to when the button is clicked
 -  text: text to display on the button
@@ -443,10 +451,16 @@ Sample Action Button Class
    "fa-calendar"
 -  additional_classes: a space-separated list of classes to include on
    the button element
+-  additional_styles: a string containing additional styles to add to the button
+-  override_classes: a space-separated list of classes to place on the control that will replace the default classes
+-  override_styles: a string containing the styles to be applied to the control
 -  message: confirmation message to display if ‘confirmation’ class is
    added to additional classes
 -  append_id: if True, add id_field_name=id_value to the url querystring
    for the button
+-  name: the name to apply to the control
+-  ignore_attribute_plugin: boolean - respect the attribute plugin specified on the grid or ignore it
+-  attrs: additional attributes to apply to the control
 
 After defining the custom GridActionButton class, you need to define
 your Action buttons:

--- a/py4web/utils/grid.py
+++ b/py4web/utils/grid.py
@@ -629,7 +629,11 @@ class Grid:
                     self.form.param.submit_value = self.param.edit_submit_value
 
             # redirect to the referrer
-            if self.form.accepted or (readonly and request.method == "POST") or (self.form.deletable and self.form.deleted):
+            if (
+                self.form.accepted
+                or (readonly and request.method == "POST")
+                or (self.form.deletable and self.form.deleted)
+            ):
                 referrer = request.query.get("_referrer")
                 if referrer:
                     redirect(base64.b16decode(referrer.encode("utf8")).decode("utf8"))
@@ -766,11 +770,13 @@ class Grid:
         url,
         button_text,
         icon,
+        icon_size="small",  # deprecated
         additional_classes=None,
         additional_styles=None,
         override_classes=None,
         override_styles=None,
         message=None,
+        onclick=None,  # deprecated
         row_id=None,
         name="grid-button",
         row=None,
@@ -1111,7 +1117,7 @@ class Grid:
                 attrs = (
                     self.attributes_plugin.confirm(message=self.T(btn.message))
                     if btn.message and btn.message != ""
-                    else btn.__dict__.get('attrs', dict())
+                    else btn.__dict__.get("attrs", dict())
                 )
 
                 cat.append(
@@ -1120,8 +1126,12 @@ class Grid:
                         button_text=self.T(btn.text),
                         icon=btn.icon,
                         additional_classes=btn.additional_classes,
+                        additional_styles=btn.__dict__.get("override_styles"),
+                        override_classes=btn.__dict__.get("override_classes"),
+                        override_styles=btn.__dict__.get("override_styles"),
                         message=btn.message,
                         row_id=row_id if btn.append_id else None,
+                        name=btn.__dict__.get("name"),
                         row=row,
                         ignore_attribute_plugin=btn.ignore_attribute_plugin
                         if "ignore_attribute_plugin" in btn.__dict__
@@ -1194,7 +1204,7 @@ class Grid:
                 attrs = (
                     self.attributes_plugin.confirm(message=self.T(btn.message))
                     if btn.message and btn.message != ""
-                    else dict()
+                    else btn.__dict__.get("attrs", dict())
                 )
                 cat.append(
                     self._make_action_button(
@@ -1202,8 +1212,12 @@ class Grid:
                         button_text=self.T(btn.text),
                         icon=btn.icon,
                         additional_classes=btn.additional_classes,
+                        additional_styles=btn.__dict__.get("override_styles"),
+                        override_classes=btn.__dict__.get("override_classes"),
+                        override_styles=btn.__dict__.get("override_styles"),
                         message=btn.message,
                         row_id=row_id if btn.append_id else None,
+                        name=btn.__dict__.get("name"),
                         row=row,
                         ignore_attribute_plugin=btn.ignore_attribute_plugin
                         if "ignore_attribute_plugin" in btn.__dict__
@@ -1280,12 +1294,22 @@ class Grid:
                 elif callable(element):
                     grid_header.append(element())
                 else:
-                    if element.override_classes and element.override_classes != '':
-                        override_classes = element.override_classes
-                    else:
-                        override_classes = self.param.grid_class_style.classes.get(
+                    override_classes = element.__dict__.get("override_classes", None)
+                    if not override_classes:
+                        override_classes = (
+                            self.param.grid_class_style.classes.get(
                                 "grid-header-element", ""
-                            ) + f" {element.additional_classes}"
+                            )
+                            + f" {element.additional_classes}"
+                        )
+                    override_styles = element.__dict__.get("override_styles", None)
+                    if not override_styles:
+                        override_styles = (
+                            self.param.grid_class_style.styles.get(
+                                "grid-trailer-element", ""
+                            )
+                            + f" {element.__dict__.get('additional_styles')}"
+                        )
                     grid_header.append(
                         self._make_action_button(
                             url=element.url,
@@ -1293,13 +1317,13 @@ class Grid:
                             icon=element.icon,
                             icon_size="normal",
                             additional_classes=element.additional_classes,
-                            message=element.message,
+                            additional_styles=element.__dict__.get("additional_styles"),
                             override_classes=override_classes,
-                            override_styles=self.param.grid_class_style.styles.get(
-                                "grid-trailer-element"
-                            ),
+                            override_styles=override_styles,
+                            message=element.message,
+                            name=element.__dict__.get("name"),
                             ignore_attributes_plugin=element.ignore_attribute_plugin,
-                            **element.__dict__.get('attrs', dict())
+                            **element.__dict__.get("attrs", dict()),
                         )
                     )
 
@@ -1351,6 +1375,22 @@ class Grid:
                 elif callable(element):
                     html.append(element())
                 else:
+                    override_classes = element.__dict__.get("override_classes", None)
+                    if not override_classes:
+                        override_classes = (
+                            self.param.grid_class_style.classes.get(
+                                "grid-footer-element", ""
+                            )
+                            + f" {element.additional_classes}"
+                        )
+                    override_styles = element.__dict__.get("override_styles", None)
+                    if not override_styles:
+                        override_styles = (
+                            self.param.grid_class_style.styles.get(
+                                "grid-footer-element", ""
+                            )
+                            + f" {element.__dict__.get('additional_styles')}"
+                        )
                     html.append(
                         self._make_action_button(
                             url=element.url,
@@ -1358,13 +1398,13 @@ class Grid:
                             icon=element.icon,
                             icon_size="normal",
                             additional_classes=element.additional_classes,
+                            additional_styles=element.__dict__.get("additional_styles"),
+                            override_classes=override_classes,
+                            override_styles=override_styles,
                             message=element.message,
-                            override_classes=self.param.grid_class_style.classes.get(
-                                "grid-footer-element", ""
-                            ),
-                            override_styles=self.param.grid_class_style.styles.get(
-                                "grid-footer-element"
-                            ),
+                            name=element.__dict__.get("name"),
+                            ignore_attributes_plugin=element.ignore_attribute_plugin,
+                            **element.__dict__.get("attrs", dict()),
                         )
                     )
 


### PR DESCRIPTION
This PR does 2 things

1. When submitting a form (from a grid) with 'check to delete' checked, the grid did not redirect correctly on successful delete. This is fixed here.
2. A number of changes to clean up the Action Button implementation
- allow common signature
- note that 2 parameters to _make_action_button are deprecated
- handle css/style overrides better in header/trailer elements

Docs, Chapter 14 has been updated to reflect the GridActionButton parameters.

NOTE - I'm using the technique object.__dict__.get('key_name', default) to retrieve object attributes that may not exist.  Is there a performance penalty for doing that?  I used this for backward compatibility where the attribute may not be passed.  If you want this handled a different way let me know a better implementation and I can change throughout.

I think it would be beneficial if we provided a GridActionButton class in grid.py so that developers could import/use it when building custom buttons.  It would look like this:

```
class GridActionButton:
    def __init__(
        self,
        url,
        text=None,
        icon=None,
        additional_classes="",
        additional_styles="",
        override_classes="",
        override_styles="",
        message="",
        append_id=False,
        name=None,
        ignore_attribute_plugin=False,
        **attrs
    ):
        self.url = url
        self.text = text
        self.icon = icon
        self.additional_classes = additional_classes
        self.additional_styles = additional_styles
        self.override_classes = override_classes
        self.override_styles = override_styles
        self.message = message
        self.append_id = append_id
        self.name = name
        self.ignore_attribute_plugin = ignore_attribute_plugin
        self.attrs = attrs
```
I did not include it in this PR.  Is that something that you could support?  If so, I'll submit a new PR for it.