### PR TITLE
Expose API models typo

### DIFF
--- a/py4web/utils/auth.py
+++ b/py4web/utils/auth.py
@@ -1073,7 +1073,7 @@ class AuthAPI:
     @staticmethod
     @api_wrapper
     def all_models(auth):
-        if not auth.param.get("expose_all_models"):
+        if not auth.param.expose_all_models:
             return HTTP(404)
         available_models = [item for item in AuthAPI.model_apis if auth.allows(item)]
         request.query["@model"] = "true"


### PR DESCRIPTION
Typo correction. Param object doesn't have a get method so an error occurs if you attempt to get the models currently, i.e. start up py4web and go to [http://127.0.0.1:8000/_scaffold/auth/api/all_models](http://127.0.0.1:8000/_scaffold/auth/api/all_models).