### PR TITLE
Url_signer session independent

### DIFF
--- a/py4web/utils/url_signer.py
+++ b/py4web/utils/url_signer.py
@@ -121,7 +121,6 @@ class URLSigner(Fixture):
 
     def on_request(self, context):
         """Creates the signing key if necessary."""
-        print("on_request", self.session.get("_signature_key"))        
         if self.session is not None and self.session.get("_signature_key") is None:
             key = str(uuid.uuid1())
             self.session["_signature_key"] = key


### PR DESCRIPTION
The line 124 in url_signer.py
https://github.com/web2py/py4web/blob/master/py4web/utils/url_signer.py#L124

`print("on_request", self.session.get("_signature_key"))`

It raises an error when the session paramenter is not inlcuded in URLsigner.  So it is no posible to declare 
`url_signer = URLSigner()  `

or put a key parameter.
`url_signer = URLSigner(key=URL_SIGNER_KEY)`

Then it is possilbe to make url_signer session independent.