### PR TITLE
fix grid form search style

### DIFF
--- a/py4web/utils/grid.py
+++ b/py4web/utils/grid.py
@@ -100,6 +100,8 @@ class GridClassStyle:
         "grid-search-form-table": "grid-search-form-table",
         "grid-search-form-tr": "grid-search-form-tr",
         "grid-search-form-td": "grid-search-form-td",
+        "grid-search-form-input": "grid-search-form-input",
+        "grid-search-form-select": "grid-search-form-select",
         "grid-search-boolean": "grid-search-boolean",
         "grid-header-element": "grid-header-element info",
         "grid-footer-element": "grid-footer-element info",
@@ -146,6 +148,8 @@ class GridClassStyle:
         "grid-search-form-table": "",
         "grid-search-form-tr": "border-bottom: none;",
         "grid-search-form-td": "",
+        "grid-search-form-input": "",
+        "grid-search-form-select": "",
         "grid-search-boolean": "",
         "grid-header-element": "margin-top:4px; height:34px; line-height:34px;",
         "grid-footer-element": "margin-top:4px; height:34px; line-height:34px;",
@@ -205,6 +209,8 @@ class GridClassStyleBulma(GridClassStyle):
         "grid-search-form-table": "grid-search-form-table",
         "grid-search-form-tr": "grid-search-form-tr",
         "grid-search-form-td": "grid-search-form-td pr-1",
+        "grid-search-form-input": "grid-search-form-input input",
+        "grid-search-form-select": "grid-search-form-input control select",
         "grid-search-boolean": "grid-search-boolean",
         "grid-header-element": "grid-header-element button",
         "grid-footer-element": "grid-footer-element button",
@@ -252,6 +258,8 @@ class GridClassStyleBulma(GridClassStyle):
         "grid-search-form-table": "",
         "grid-search-form-tr": "",
         "grid-search-form-td": "",
+        "grid-search-form-input": "",
+        "grid-search-form-select": "",
         "grid-search-boolean": "padding-top: .5rem;",
         "grid-header-element": "",
         "grid-footer-element": "",
@@ -851,16 +859,20 @@ class Grid:
         ]
         attrs = self.attributes_plugin.link(url=self.endpoint)
         form = FORM(*hidden_fields, **attrs)
+        sc = _class = self.param.grid_class_style.get("grid-search-form-select")
         select = SELECT(
             *options,
             **dict(
                 _name="search_type",
             ),
+            **sc,
         )
+        sc = self.param.grid_class_style.get("grid-search-form-input")
         input = INPUT(
             _type="text",
             _name="search_string",
             _value=search_string,
+            **sc,
         )
         sc = self.param.grid_class_style.get("grid-search-button")
         submit = INPUT(_type="submit", _value=self.T("Search"), **sc)


### PR DESCRIPTION
In the Grid search form that is generated using the search_queries option, there are no styles or css classes in GridClassStyle or GridClassStyleBulma for the <input> and <select> form elements.

Now this HTML is generated:
<select name="search_type">
<input name="search_string" type="text">

With the modification this HTML is generated:
<select class="grid-search-form-input control select" name="search_type" style=""> <input class="grid-search-form-input input" name="search_string" style="" type="text">