### PR TITLE
Add dkim support to mails

### DIFF
--- a/py4web/utils/mailer.py
+++ b/py4web/utils/mailer.py
@@ -215,6 +215,7 @@ class Mailer:
         settings.timeout = 5  # seconds
         settings.hostname = None
         settings.dkim = None
+        settings.list_unsubscribe = None
         settings.ssl = ssl
         settings.cipher_type = None
         settings.gpg_home = None
@@ -244,6 +245,7 @@ class Mailer:
         headers={},
         from_address=None,
         dkim=None,
+        list_unsubscribe=None,
         cipher_type=None,
         sign=None,
         sign_passphrase=None,
@@ -741,6 +743,10 @@ class Mailer:
         payload["Date"] = email.utils.formatdate()
         for k, v in iteritems(headers):
             payload[k] = encoded_or_raw(to_unicode(v, encoding))
+
+        list_unsubscribe = list_unsubscribe or self.settings.list_unsubscribe
+        if list_unsubscribe:
+            payload['List-Unsubscribe'] = "<mailto:%s>" % list_unsubscribe
 
         dkim = dkim or self.settings.dkim
         if dkim:

--- a/py4web/utils/mailer.py
+++ b/py4web/utils/mailer.py
@@ -214,6 +214,7 @@ class Mailer:
         settings.tls = tls
         settings.timeout = 5  # seconds
         settings.hostname = None
+        settings.dkim = None
         settings.ssl = ssl
         settings.cipher_type = None
         settings.gpg_home = None
@@ -242,6 +243,7 @@ class Mailer:
         raw=False,
         headers={},
         from_address=None,
+        dkim=None,
         cipher_type=None,
         sign=None,
         sign_passphrase=None,
@@ -739,6 +741,11 @@ class Mailer:
         payload["Date"] = email.utils.formatdate()
         for k, v in iteritems(headers):
             payload[k] = encoded_or_raw(to_unicode(v, encoding))
+
+        dkim = dkim or self.settings.dkim
+        if dkim:
+            payload['DKIM-Signature'] = dkim_sign(payload, dkim.key, dkim.selector)
+
         result = {}
         try:
             if self.settings.server == "logging":

--- a/py4web/utils/mailer.py
+++ b/py4web/utils/mailer.py
@@ -839,3 +839,34 @@ class Mailer:
         self.result = result
         self.error = None
         return True
+
+
+def dkim_sign(payload, dkim_key, dkim_selector):
+
+    import dkim
+
+    # sign all existing mail headers except those specified in
+    # http://dkim.org/specs/rfc4871-dkimbase.html#rfc.section.5.5
+    headers = list(filter(
+        lambda h: h not in [
+            "Return-Path",
+            "Received",
+            "Comments",
+            "Keywords",
+            "Resent-Bcc",
+            "Bcc",
+            "DKIM-Signature",
+        ],
+        payload))
+
+    domain = re.sub(r".*@", "", payload["From"])
+    domain = re.sub(r">.*", "", domain)
+
+    sig = dkim.sign(
+            message=payload.as_bytes(),
+            selector=dkim_selector.encode(),
+            domain=domain.encode(),
+            privkey=dkim_key.encode(),
+            include_headers=[h.encode() for h in headers])
+
+    return sig[len("DKIM-Signature: "):].decode()


### PR DESCRIPTION
add support to `Mailer.send()` for the following spam-filters facilitating mail content:

- DKIM (requires install of `dkimpy`)
- List-Unsubscribe

example usage (global configuration e.g. via `models/db.py`):
```
dkim_key_path = myconf.get("dkim.key", default=default_dkim_key_path)
if path.exists(dkim_key_path):
    class dkim:
        key = open(dkim_key_path).read()
        selector = myconf.get("dkim.selector", default="s1024")

    mail.settings.dkim = dkim


list_unsubscribe = myconf.get("contact.email")
if list_unsubscribe:
    mail.settings.list_unsubscribe = list_unsubscribe
```