### PR TITLE
A tiny PR for launch.json and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ Thumbs.db
 ./*.zip
 apps/_documentation/static/*/*.pdf
 apps/_documentation/static/*/*.epub
-apps/*
+apps*/*
 !apps/todo/*
 !apps/showcase/*
 !apps/_dashboard/*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,8 +4,9 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
+
         {
-            "name": "Python: Current File",
+            "name": "Python: py4web",
             "type": "python",
             "request": "launch",
             "program": "py4web.py",


### PR DESCRIPTION
* In launch.json, the name of the configuration is now "Run py4web" rather than "Run current file", which is more appropriate since it is py4web that is run
* I added to .gitignore apps*/* so I can have a folder called apps_inactive/ under which I can put all the apps I do not want to be loaded (and keep them out of git). 
