### PR TITLE
Remove doc about IRC py4web channel as it is empty

### DIFF
--- a/apps/_documentation/static/en/chapter-02.html
+++ b/apps/_documentation/static/en/chapter-02.html
@@ -49,7 +49,6 @@
 <li class="toctree-l2"><a class="reference internal" href="#resources">Resources</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="#this-manual">This manual</a></li>
 <li class="toctree-l3"><a class="reference internal" href="#the-google-group">The Google group</a></li>
-<li class="toctree-l3"><a class="reference internal" href="#the-chat-on-irc">The chat on IRC</a></li>
 <li class="toctree-l3"><a class="reference internal" href="#the-discord-server">The Discord server</a></li>
 <li class="toctree-l3"><a class="reference internal" href="#tutorials-and-video">Tutorials and video</a></li>
 <li class="toctree-l3"><a class="reference internal" href="#the-sources-on-github">The sources on GitHub</a></li>
@@ -119,12 +118,6 @@ But don’t be scared, in this manual we’ll assist you side by side in this jo
 <section id="the-google-group">
 <h3>The Google group<a class="headerlink" href="#the-google-group" title="Permalink to this heading"></a></h3>
 <p>There is a dedicated mailing list hosted on Google Groups, see <a class="reference external" href="https://groups.google.com/g/py4web">https://groups.google.com/g/py4web</a>. This is the main source of discussions for developers and simple users. For any problem you should face, this is the right place to search for a hint or a solution.</p>
-</section>
-<section id="the-chat-on-irc">
-<h3>The chat on IRC<a class="headerlink" href="#the-chat-on-irc" title="Permalink to this heading"></a></h3>
-<p>We also use to chat sometime on IRC (Internet Relay Chat, which is an old-style text only chat). You can freely join us at <a class="reference external" href="https://webchat.freenode.net/#py4web">https://webchat.freenode.net/#py4web</a>.
-From time to time we also use it to host a scheduled public chat, where you can write and read live questions to developers.
-Transcripts of them are then available on the mailing list.</p>
 </section>
 <section id="the-discord-server">
 <h3>The Discord server<a class="headerlink" href="#the-discord-server" title="Permalink to this heading"></a></h3>

--- a/apps/_documentation/static/pt/chapter-02.html
+++ b/apps/_documentation/static/pt/chapter-02.html
@@ -50,7 +50,6 @@
 <li class="toctree-l2"><a class="reference internal" href="#resources">Recursos</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="#this-manual">Este manual</a></li>
 <li class="toctree-l3"><a class="reference internal" href="#the-google-group">O grupo Google</a></li>
-<li class="toctree-l3"><a class="reference internal" href="#the-chat-on-irc">O bate-papo no IRC</a></li>
 <li class="toctree-l3"><a class="reference internal" href="#the-discord-server">The Discord server</a></li>
 <li class="toctree-l3"><a class="reference internal" href="#tutorials-and-video">Tutoriais e vídeo</a></li>
 <li class="toctree-l3"><a class="reference internal" href="#the-sources-on-github">As fontes no GitHub</a></li>
@@ -118,10 +117,6 @@
 <section id="the-google-group">
 <h3>O grupo Google<a class="headerlink" href="#the-google-group" title="Permalink to this heading"></a></h3>
 <p>Existe uma lista de discussão dedicado hospedado no Google Groups, consulte <a class="reference external" href="https://groups.google.com/g/py4web">https://groups.google.com/g/py4web</a>. Esta é a principal fonte de discussões para desenvolvedores e usuários simples. Para qualquer problema que você deve enfrentar, este é o lugar certo para procurar uma dica ou uma solução.</p>
-</section>
-<section id="the-chat-on-irc">
-<h3>O bate-papo no IRC<a class="headerlink" href="#the-chat-on-irc" title="Permalink to this heading"></a></h3>
-<p>Nós também usamos para conversar em algum momento no IRC (Internet Relay Chat, que é um texto de estilo antigo única chat). Você pode se juntar a nós livremente no <a class="reference external" href="https://webchat.freenode.net/#py4web">https://webchat.freenode.net/#py4web</a>. De vez em quando nós também usá-lo para hospedar um bate-papo pública agendada, onde você pode escrever e ler perguntas ao vivo para os desenvolvedores. Transcrições deles são, então, disponível na lista de discussão.</p>
 </section>
 <section id="the-discord-server">
 <h3>The Discord server<a class="headerlink" href="#the-discord-server" title="Permalink to this heading"></a></h3>

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,22 +52,22 @@ The current official translators are listed here:
 
 If your language does not still exist in the documentation, for example the Italian one, you need to build its PO files. Setup a working environment as described before for updatDocs.sh, go to the
 /docs folder and run:
-
+```
 make gettext
 sphinx-intl update -p _build/gettext -l it
+```
+(where 'it' is the language code for Italian).  
+This will create the PO files to be translated in `/docs/locales/it/LC_MESSAGES`
 
-(where 'it' is the language code for Italian).
-This will create the PO files to be translated in /docs/locales/it/LC_MESSAGES
-
-After their translation, make a PR for them. If you want, you can also generate the local HTML outputs as usual with the updateDocs.sh program.
+After their translation, make a PR for them. If you want, you can also generate the local HTML outputs as usual with the `updateDocs.sh` program.
 
 ## Update translation
 
 When the english source files will be updated, the translated work will not be lost - but the new strings will appear inside your translated ones.
 In order import the updated sources without loosing your previous work, you need to run:
-
+```
 sphinx-build -b gettext . _build/gettext
-
+```
 This creates the updates .pot files on /docs/_build/gettext. 
 With poedit you have to load the old translated .po file in your language. Then you use the menu "Catalog" -> "Update from POT file ..." in order to collect the updates from the .pot file.
 The new additions / changes will be loaded and marked to be fixed. You can now save the updated PO file and work on it. 

--- a/docs/chapter-02.rst
+++ b/docs/chapter-02.rst
@@ -21,12 +21,6 @@ The Google group
 
 There is a dedicated mailing list hosted on Google Groups, see https://groups.google.com/g/py4web. This is the main source of discussions for developers and simple users. For any problem you should face, this is the right place to search for a hint or a solution.
 
-The chat on IRC
----------------
-
-We also use to chat sometime on IRC (Internet Relay Chat, which is an old-style text only chat). You can freely join us at https://webchat.freenode.net/#py4web.
-From time to time we also use it to host a scheduled public chat, where you can write and read live questions to developers.
-Transcripts of them are then available on the mailing list.
 
 The Discord server
 -------------------

--- a/docs/locales/pt/LC_MESSAGES/chapter-02.po
+++ b/docs/locales/pt/LC_MESSAGES/chapter-02.po
@@ -81,25 +81,6 @@ msgstr ""
 "para desenvolvedores e usuários simples. Para qualquer problema que você "
 "deve enfrentar, este é o lugar certo para procurar uma dica ou uma solução."
 
-#: ../../chapter-02.rst:30
-msgid "The chat on IRC"
-msgstr "O bate-papo no IRC"
-
-#: ../../chapter-02.rst:32
-msgid ""
-"We also use to chat sometime on IRC (Internet Relay Chat, which is an old-"
-"style text only chat). You can freely join us at https://webchat.freenode."
-"net/#py4web. From time to time we also use it to host a scheduled public "
-"chat, where you can write and read live questions to developers. "
-"Transcripts of them are then available on the mailing list."
-msgstr ""
-"Nós também usamos para conversar em algum momento no IRC (Internet Relay "
-"Chat, que é um texto de estilo antigo única chat). Você pode se juntar a "
-"nós livremente no https://webchat.freenode.net/#py4web. De vez em quando "
-"nós também usá-lo para hospedar um bate-papo pública agendada, onde você "
-"pode escrever e ler perguntas ao vivo para os desenvolvedores. Transcrições "
-"deles são, então, disponível na lista de discussão."
-
 #: ../../chapter-02.rst:38
 msgid "Tutorials and video"
 msgstr "Tutoriais e vídeo"


### PR DESCRIPTION
Look like IRC is not actual anymore with discord and other options.
Thus lets drop Documentation referring to IRC channel

Also Cosmetic change for docs/README.md