### PR TITLE
Improved Google Oauth with credentials 

### DIFF
--- a/deployment_tools/gae/app.yaml
+++ b/deployment_tools/gae/app.yaml
@@ -1,4 +1,4 @@
-runtime: python37
+runtime: python311
 
 # Handlers define how to route requests to your application.
 handlers:

--- a/deployment_tools/gae/main.py
+++ b/deployment_tools/gae/main.py
@@ -2,10 +2,11 @@ import os
 import site
 site.addsitedir(os.path.join(os.path.dirname(__file__), 'lib'))
 from py4web.core import Reloader, bottle, Session
-os.environ['PY4WEB_DASHBOARD_MODE'] = 'demo'
+os.environ['PY4WEB_DASHBOARD_MODE'] = 'none'
 os.environ['PY4WEB_SERVICE_DB_URI'] = 'sqlite:memory'
 os.environ['PY4WEB_APPS_FOLDER'] = os.path.join(os.path.dirname(__file__), 'apps')
 os.environ['PY4WEB_SERVICE_FOLDER'] = os.path.join(os.path.dirname(__file__), 'apps/.service')
-Session.SECRET = open(os.path.join(os.path.dirname(__file__), 'apps/.service/session.secret'), 'rb').read()
+# Session.SECRET = open(os.path.join(os.path.dirname(__file__), 'apps/.service/session.secret'), 'rb').read()
+Session.SECRET = "81738cc8-44a3-4bfd-b535-9973492gfufg6374"
 Reloader.import_apps()
 app = bottle.default_app()

--- a/deployment_tools/gae/main.py
+++ b/deployment_tools/gae/main.py
@@ -5,8 +5,7 @@ from py4web.core import Reloader, bottle, Session
 os.environ['PY4WEB_DASHBOARD_MODE'] = 'none'
 os.environ['PY4WEB_SERVICE_DB_URI'] = 'sqlite:memory'
 os.environ['PY4WEB_APPS_FOLDER'] = os.path.join(os.path.dirname(__file__), 'apps')
-os.environ['PY4WEB_SERVICE_FOLDER'] = os.path.join(os.path.dirname(__file__), 'apps/.service')
-# Session.SECRET = open(os.path.join(os.path.dirname(__file__), 'apps/.service/session.secret'), 'rb').read()
-Session.SECRET = "81738cc8-44a3-4bfd-b535-9973492gfufg6374"
+os.environ['PY4WEB_SERVICE_FOLDER'] = os.path.join(os.path.dirname(__file__), '.service')
+Session.SECRET = open(os.path.join(os.path.dirname(__file__), '.service/session.secret'), 'rb').read()
 Reloader.import_apps()
 app = bottle.default_app()

--- a/py4web/utils/auth.py
+++ b/py4web/utils/auth.py
@@ -92,13 +92,32 @@ class AuthEnforcer(Fixture):
             )
         )
 
+    def goto_login(self, message=""):
+        """Goes to the proper login page."""
+        # If a plugin can handle requests, redirects to the login url for the login.
+        for plugin in self.auth.plugins.values():
+            if hasattr(plugin, "handle_request"):
+                if re.search(REGEX_APPJSON,
+                             request.headers.get("accept", "")) and (
+                        request.headers.get("json-redirects", "") != "on"
+                ):
+                    raise HTTP(403)
+                redirect_next = request.fullpath
+                if request.query_string:
+                    redirect_next = redirect_next + "?{}".format(request.query_string)
+                redirect(
+                    URL(self.auth.route, "plugin", plugin.name, "login",
+                        vars=dict(next=redirect_next)))
+        # Otherwise, uses the normal login.
+        self.abort_or_redirect("login", message=message)
+
     def on_request(self, context):
         """Checks that we have a user in the session and
         the condition is met"""
         user = self.auth.session.get("user")
         if not user or not user.get("id"):
             self.auth.session["recent_activity"] = None
-            self.abort_or_redirect("login", "User not logged in")
+            self.goto_login(message="User not logged in")
         activity = self.auth.session.get("recent_activity")
         time_now = calendar.timegm(time.gmtime())
         # enforce the optionl auth session expiration time
@@ -108,6 +127,8 @@ class AuthEnforcer(Fixture):
             and time_now - activity > self.auth.param.login_expiration_time
         ):
             del self.auth.session["user"]
+            self.goto_login(message="Login expired")
+            # Otherwise, uses the normal login.
             self.abort_or_redirect("login", "Login expired")
         # record the time of the latest activity for logged in user (with throttling)
         if not activity or time_now - activity > 6:
@@ -1183,6 +1204,7 @@ class AuthAPI:
                 data = auth._error(
                     auth.param.messages["errors"].get("invalid_credentials")
                 )
+
         # Else use normal login
         else:
             user, error = auth.login(username, password)

--- a/py4web/utils/auth.py
+++ b/py4web/utils/auth.py
@@ -259,6 +259,7 @@ class Auth(Fixture):
             two_factor_required=two_factor_required,
             two_factor_send=two_factor_send,
             two_factor_tries=3,
+            auth_enforcer=None,
         )
 
         # callbacks for forms
@@ -472,11 +473,11 @@ class Auth(Fixture):
     @property
     def user(self):
         """Use as @action.uses(auth.user)"""
-        return AuthEnforcer(self)
+        return self.param.auth_enforcer if self.param.auth_enforcer else AuthEnforcer(self)
 
     def condition(self, condition):
         """Use as @action.uses(auth.condition(lambda user: True))"""
-        return AuthEnforcer(self, condition)
+        return self.param.auth_enforcer if self.param.auth_enforcer else AuthEnforcer(self, condition)
 
     # utilities
     def get_user(self, safe=True):

--- a/py4web/utils/auth_plugins/oauth2google_scoped.py
+++ b/py4web/utils/auth_plugins/oauth2google_scoped.py
@@ -58,7 +58,22 @@ class AuthEnforcerGoogleScoped(AuthEnforcer):
 
 class OAuth2GoogleScoped(object):
     """Class that enables google login via oauth2 with additional scopes.
-    The authorization info is saved so the scopes can be used later on."""
+    The authorization info is saved so the scopes can be used later on.
+
+    NOTE: if you use this plugin, it is also recommended that you set:
+
+        auth.param.auth_enforcer = AuthEnforcerGoogleScoped(auth, error_page="credentials_error")
+
+    and that you create a page at URL("credentials_error") to explain the user
+    that their credentials have expired, and that they must log in again.
+
+    This because sometimes, when one tries to use the credentials, Google
+    complains that the refresh action fails due to missing credentials.
+    This can happen if the user, or Google, has revoked credentials.
+    We need to catch this error, and log out the user, so the user
+    can decide whether they want to login (and create credentials) again.
+
+    """
 
     # These values are used for the plugin registration.
     name = "oauth2googlescoped"

--- a/py4web/utils/auth_plugins/oauth2google_scoped.py
+++ b/py4web/utils/auth_plugins/oauth2google_scoped.py
@@ -7,15 +7,54 @@
 
 import calendar
 import json
+import re
 import time
 import uuid
 
 import google_auth_oauthlib.flow
 import google.oauth2.credentials
 from googleapiclient.discovery import build
+from google.auth.exceptions import RefreshError
 
 from py4web import request, redirect, URL, HTTP
 from pydal import Field
+from py4web.utils.auth import AuthEnforcer, REGEX_APPJSON
+
+
+class AuthEnforcerGoogleScoped(AuthEnforcer):
+    """This class catches certain invalid access errors Google generates
+    when credentials get stale, and forces the user to login again.
+    Pass it to Auth as param.auth_enfoercer, as in:
+    auth.param.auth_enforcer = AuthEnforcerGoogleScoped(auth)
+    """
+
+    def __init__(self, auth, condition=None, error_page=None):
+        super().__init__(auth, condition=condition)
+        self.error_page = error_page
+        assert error_page is not None, "You need to specify an error page; can't use login."
+
+    def on_error(self, context):
+        if isinstance(context.get("exception"), RefreshError):
+            del context["exception"]
+            self.auth.session.clear()
+            if re.search(REGEX_APPJSON,
+                         request.headers.get("accept", "")) and (
+                    request.headers.get("json-redirects", "") != "on"
+            ):
+                raise HTTP(403)
+            redirect_next = request.fullpath
+            if request.query_string:
+                redirect_next = redirect_next + "?{}".format(
+                    request.query_string)
+            self.auth.flash.set("Invalid credentials")
+            redirect(
+                URL(
+                    self.error_page,
+                    vars=dict(next=redirect_next),
+                    use_appname=self.auth.param.use_appname_in_redirects,
+                )
+            )
+
 
 class OAuth2GoogleScoped(object):
     """Class that enables google login via oauth2 with additional scopes.
@@ -70,7 +109,7 @@ class OAuth2GoogleScoped(object):
         self._db.define_table('auth_credentials', [
             Field('email'),
             Field('name'), # First and last names, all together.
-            Field('profile_pic'), # URL of profile pic.
+            Field('profile_pic', 'text'), # URL of profile pic.
             Field('credentials', 'text') # Credentials for access, stored in Json for generality.
         ])
 


### PR DESCRIPTION
* Improved Google Oauth with credentials.  I now include an auth enforcer that catches credential expiration, and logs out user. 
* Google appengine now uses runtime 311 rather than the old 37
* launch.json for vscode also allows running an individual file. 
* No dashboard by default if deployed on appengine
* auth now accepts as a parameter an authenforcer. 
* Some bug fixes in the google oauth2 login with credentials. 
