### PR TITLE
adding load config from module or py-file

### DIFF
--- a/py4web/gunicorn.rst
+++ b/py4web/gunicorn.rst
@@ -1,5 +1,7 @@
-gunicorn
-~~~~~~~~
+====================
+gunicorn with py4web
+====================
+
 
 The gunicorn server starts in the usual way for the py4web
 
@@ -8,8 +10,9 @@ The gunicorn server starts in the usual way for the py4web
    $./py4web.py run apps -s gunicorn --watch=off
    $
    $./py4web.py run apps -s gunicornGevent --watch=off
-   $
-   $ # gunicornGevent === gunicorn + monkey.patch_all() 
+
+
+gunicornGevent === gunicorn + monkey.patch_all() 
 
 It is possible to use several methods to configure gunicorn options with py4web
 
@@ -33,10 +36,13 @@ Let's show examples
 
 
 
-* set gunicorn options via config file py4web/gunicorn.saenv 
+
+* set gunicorn options via config file gunicorn.saenv 
 
   ::
 
+   # example gunicorn.saenv
+   #
    export GUNICORN_worker_tmp_dir=/dev/shm
    export GUNICORN_max_requests=1200
    worker_class=gthread
@@ -53,23 +59,23 @@ Let's show examples
    # use_python_config=python:mod_name
 
 
-* set gunicorn options via python file  py4web/myguni.conf.py
+* set gunicorn options via python file myguni.conf.py
 
  ::
 
-   set the variable use_python_config=myguni.conf.py
+   set the env variable use_python_config=myguni.conf.py
 
  .. code:: bash
 
    $ # via env
    $export GUNCORN_use_python_config=myguni.conf.py
    $ 
-   $ # via py4web/gunicorn.saenv 
-   $echo use_python_config=mmyguni.conf.py >> py4web/gunicorn.saenv
+   $ # via gunicorn.saenv 
+   $echo use_python_config=mmyguni.conf.py >> gunicorn.saenv
 
  ::
 
-   write file py4web/myguni.conf.py
+   write file myguni.conf.py
 
  .. code:: python
 
@@ -86,7 +92,8 @@ Let's show examples
 
  ::
 
-  ./py4web.py run apps -s gunicorn 
+   $ ./py4web.py run apps -s gunicorn --watch=off
+
 
 * set gunicorn options via python module
 
@@ -97,16 +104,16 @@ Let's show examples
  .. code:: bash
 
 
-  $ cd py4web && mkdir mod_name && cp myguni.conf.py mod_name/__init__.py
+  $  mkdir mod_name && cp myguni.conf.py mod_name/__init__.py
   $
   $ # via env
   $export GUNCORN_use_python_config=python:mod_name
   $
-  $ # via py4web/gunicorn.saenv
-  $echo use_python_config=python:mod_name >> py4web/gunicorn.saenv
+  $ # via gunicorn.saenv
+  $echo use_python_config=python:mod_name >> gunicorn.saenv
 
   
  ::
 
-  ./py4web.py run apps -s gunicorn 
+   $ ./py4web.py run apps -s gunicorn --watch=off
 

--- a/py4web/gunicorn.rst
+++ b/py4web/gunicorn.rst
@@ -1,0 +1,112 @@
+gunicorn
+~~~~~~~~
+
+The gunicorn server starts in the usual way for the py4web
+
+::
+
+   $./py4web.py run apps -s gunicorn --watch=off
+   $
+   $./py4web.py run apps -s gunicornGevent --watch=off
+   $
+   $ # gunicornGevent === gunicorn + monkey.patch_all() 
+
+It is possible to use several methods to configure gunicorn options with py4web
+
+Let's show examples
+
+* set gunicorn options via bash environment variables
+
+  ::
+
+   $export GUNICORN_worker_class=sync
+   $ ./py4web.py  run apps  -s gunicorn  -L 20 -w 4 --watch=off
+   $
+   $export GUNICORN_worker_class=gthread
+   $ ./py4web.py  run apps  -s gunicorn  -L 20 -w 4 --watch=off
+   $
+   $export GUNICORN_worker_class=gevent
+   $ ./py4web.py  run apps  -s gunicornGevent  -L 20 -w 4 --watch=off
+   $
+   $export GUNICORN_worker_class=eventlet
+   $ ./py4web.py  run apps  -s gunicornGevent  -L 20 -w 4 --watch=off
+
+
+
+* set gunicorn options via config file py4web/gunicorn.saenv 
+
+  ::
+
+   export GUNICORN_worker_tmp_dir=/dev/shm
+   export GUNICORN_max_requests=1200
+   worker_class=gthread
+   threads=2
+
+   # guncornGevent
+   #worker_class=gevent
+   #worker_class=eventlet
+
+   # for use python-config-file
+   # use_python_config=myguni.conf.py
+
+   # for use python-config-mod_name
+   # use_python_config=python:mod_name
+
+
+* set gunicorn options via python file  py4web/myguni.conf.py
+
+ ::
+
+   set the variable use_python_config=myguni.conf.py
+
+ .. code:: bash
+
+   $ # via env
+   $export GUNCORN_use_python_config=myguni.conf.py
+   $ 
+   $ # via py4web/gunicorn.saenv 
+   $echo use_python_config=mmyguni.conf.py >> py4web/gunicorn.saenv
+
+ ::
+
+   write file py4web/myguni.conf.py
+
+ .. code:: python
+
+   # Gunicorn configuration file
+   # https://docs.gunicorn.org/en/stable/settings.html
+   import multiprocessing
+
+   max_requests = 1000
+   max_requests_jitter = 50
+
+   log_file = "-"
+
+   workers = multiprocessing.cpu_count() * 2 + 1
+
+ ::
+
+  ./py4web.py run apps -s gunicorn 
+
+* set gunicorn options via python module
+
+ ::
+
+  write python module 
+
+ .. code:: bash
+
+
+  $ cd py4web && mkdir mod_name && cp myguni.conf.py mod_name/__init__.py
+  $
+  $ # via env
+  $export GUNCORN_use_python_config=python:mod_name
+  $
+  $ # via py4web/gunicorn.saenv
+  $echo use_python_config=python:mod_name >> py4web/gunicorn.saenv
+
+  
+ ::
+
+  ./py4web.py run apps -s gunicorn 
+

--- a/py4web/server_adapters.py
+++ b/py4web/server_adapters.py
@@ -239,10 +239,10 @@ def gunicorn():
                         except KeyError:
                             pass
 
-                    if gunicorn_vars:
-                        sa_config.update(gunicorn_vars)
-                        location = gunicorn_vars["config"]
-                        self.logger_info(f"gunicorn: used {location} {sa_config}")
+                    #if gunicorn_vars:
+                    sa_config.update(gunicorn_vars)
+                    location = gunicorn_vars["config"]
+                    self.logger_info(f"gunicorn: used {location} {sa_config}")
 
                     for k, v in sa_config.items():
                         if k not in self.cfg.settings:

--- a/py4web/server_adapters.py
+++ b/py4web/server_adapters.py
@@ -265,17 +265,18 @@ def gunicorn():
 
                     gunicorn_vars = self.get_gunicorn_vars()
 
-                    try:
-                        # test https://github.com/benoitc/gunicorn/blob/master/examples/example_config.py
-                        location = gunicorn_vars["use_native_config"]
-                        Application.load_config_from_module_name_or_filename(
-                            self, location
-                        )
-                        self.cfg.set("config", "./" + location)
-                        logger_info(f"gunicorn: used config {location}")
-                        return
-                    except KeyError:
-                        pass
+                    # test https://github.com/benoitc/gunicorn/blob/master/examples/example_config.py
+                    for e in ("use_python_config", "use_native_config"):
+                        try:
+                            location = gunicorn_vars[e]
+                            Application.load_config_from_module_name_or_filename(
+                                self, location
+                            )
+                            self.cfg.set("config", "./" + location)
+                            logger_info(f"gunicorn: used config {location}")
+                            return
+                        except KeyError:
+                            pass
 
                     if gunicorn_vars:
                         config.update(gunicorn_vars)
@@ -291,14 +292,15 @@ def gunicorn():
                             logger_info(f"gunicorn: Invalid value for {k}:{v}")
                             raise
 
-                    #if "print_config" in gunicorn_vars:
+                    # if "print_config" in gunicorn_vars:
                     #    gunicorn_vars["print_config"].lower() == "true" and logger_info( self.cfg)
 
                     try:
-                        gunicorn_vars['print_config'] == 'True' and logger_info(self.cfg)
+                        gunicorn_vars["print_config"] == "True" and logger_info(
+                            self.cfg
+                        )
                     except KeyError:
                         pass
-
 
                 def load(self):
                     return app_handler

--- a/py4web/server_adapters.py
+++ b/py4web/server_adapters.py
@@ -191,8 +191,8 @@ def gunicorn():
                                     line = line.strip()
                                     if not line or line.startswith(("#", "[")):
                                         continue
-                                    for k in ("export ", "GUNICORN_"):
-                                        line = line.replace(k, "", 1)
+                                    for e in ("export ", "GUNICORN_"):
+                                        line = line.replace(e, "", 1)
                                     k, v = None, None
                                     try:
                                         k, v = line.split("=", 1)
@@ -204,7 +204,6 @@ def gunicorn():
                                         continue
                                     result[k] = v
                                 if result:
-                                    print(f"gunicorn: read {env_file}")
                                     result["config"] = "./" + env_file
                                     return result
                         except OSError as ex:

--- a/py4web/server_adapters.py
+++ b/py4web/server_adapters.py
@@ -180,36 +180,36 @@ def gunicorn():
                                 lines = f.read().splitlines()
                                 for line in lines:
                                     line = line.strip()
-                                    if not line or line.startswith(("#",'[')):
+                                    if not line or line.startswith(("#", "[")):
                                         continue
                                     for k in ("export ", "GUNICORN_"):
-                                        line = line.replace(k, "",1)
-                                    k,v = None, None
+                                        line = line.replace(k, "", 1)
+                                    k, v = None, None
                                     try:
                                         k, v = line.split("=", 1)
                                         k, v = k.strip().lower(), v.strip()
-                                    except (ValueError, AttributeError ) :
+                                    except (ValueError, AttributeError):
                                         continue
-                                    if not v or k == 'bind':
+                                    if not v or k == "bind":
                                         continue
-                                    if v.startswith('{') and v.endswith('}'):
-                                         v = json.loads( v.replace("'", "\"") )
-                                    result[k] = None if v == 'None' else v
+                                    if v.startswith("{") and v.endswith("}"):
+                                        v = json.loads(v.replace("'", '"'))
+                                    result[k] = None if v == "None" else v
                                 if result:
                                     print(f"gunicorn: read {env_file}")
-                                    result['config'] = './' + env_file
+                                    result["config"] = "./" + env_file
                                     return result
                         except OSError as ex:
                             print(f"gunicorn: cannot read {env_file}; {ex}")
                     for k, v in os.environ.items():
                         if k.startswith("GUNICORN_") and v:
                             key = k.split("_", 1)[1].lower()
-                            if key == 'bind':
+                            if key == "bind":
                                 continue
-                            if v.startswith('{') and v.endswith('}'):
-                                 v = json.loads( v.replace("'", "\"") )
-                            result[key] = None if v == 'None' else v
-                    result['config'] = 'environ' 
+                            if v.startswith("{") and v.endswith("}"):
+                                v = json.loads(v.replace("'", '"'))
+                            result[key] = None if v == "None" else v
+                    result["config"] = "environ"
                     return result
 
                 def load_config(self):
@@ -238,7 +238,6 @@ def gunicorn():
 
                     """
 
-
                     # export GUNICORN_BACKLOG=4096
                     # export GUNICORN_worker_connections=100
 
@@ -262,37 +261,41 @@ def gunicorn():
                     #
                     # time seq 1 5000 | xargs -I % -P 0 curl http://localhost:8000/todo &>/dev/null
 
-                    def logger_info(msg='msg'):
-                        logger and logger.info (str(msg))
+                    def logger_info(msg="msg"):
+                        logger and logger.info(str(msg))
 
                     gunicorn_vars = self.get_gunicorn_vars()
 
                     try:
                         # test https://github.com/benoitc/gunicorn/blob/master/examples/example_config.py
-                        location=gunicorn_vars['use_native_config' ]
-                        Application.load_config_from_module_name_or_filename(self, location)
-                        self.cfg.set('config', './' + location)
-                        logger_info (f'gunicorn: used config {location}')
+                        location = gunicorn_vars["use_native_config"]
+                        Application.load_config_from_module_name_or_filename(
+                            self, location
+                        )
+                        self.cfg.set("config", "./" + location)
+                        logger_info(f"gunicorn: used config {location}")
                         return
                     except KeyError:
                         pass
 
                     if gunicorn_vars:
                         config.update(gunicorn_vars)
-                        location = gunicorn_vars['config']
+                        location = gunicorn_vars["config"]
                         logger_info(f"gunicorn: used config {location} {config}")
 
                     for k, v in config.items():
                         if k not in self.cfg.settings:
-                           continue
+                            continue
                         try:
                             self.cfg.set(k, v)
                         except Exception:
                             logger_info(f"gunicorn: Invalid value for {k}:{v}")
                             raise
 
-                    if 'print_config' in gunicorn_vars:
-                        gunicorn_vars['print_config'].lower() == 'true' and  print (self.cfg)
+                    if "print_config" in gunicorn_vars:
+                        gunicorn_vars["print_config"].lower() == "true" and logger_info(
+                            self.cfg
+                        )
 
                 def load(self):
                     return app_handler

--- a/py4web/server_adapters.py
+++ b/py4web/server_adapters.py
@@ -272,13 +272,13 @@ def gunicorn():
                           location=gunicorn_vars['use_native_config' ]
                           super().load_config_from_module_name_or_filename(location)
                           self.cfg.set('config', './' + location)
-                          print (f'gunicorn: used config {location}')
+                          sa_show_msg and print (f'gunicorn: used config {location}')
                           return
 
                     if gunicorn_vars:
                         config.update(gunicorn_vars)
                         location = gunicorn_vars['config']
-                        print(f"gunicorn: used config {location}", config)
+                        sa_show_msg and print(f"gunicorn: used config {location}", config)
 
                     for k, v in config.items():
                         if k not in self.cfg.settings:

--- a/py4web/server_adapters.py
+++ b/py4web/server_adapters.py
@@ -146,7 +146,7 @@ def gunicorn():
 
             logger = None
 
-            config = {
+            sa_config = {
                 "bind": f"{self.host}:{self.port}",
                 "workers": get_workers(self.options),
                 "certfile": self.options.get("certfile", None),
@@ -161,7 +161,7 @@ def gunicorn():
                 logger = logging_conf(level)
                 log_to = "-" if log_file is None else log_file
 
-                config.update(
+                sa_config.update(
                     {
                         "loglevel": logging.getLevelName(level),
                         "access_log_format": '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"',
@@ -227,6 +227,11 @@ def gunicorn():
                     use_native_config=python:example
                     use_native_config=gunicorn.conf.py
 
+                    # or
+
+                    use_python_config=python:example
+                    use_python_config=gunicorn.conf.py
+
                     # example
                     # export GUNICORN_max_requests=1200
                     export GUNICORN_worker_tmp_dir=/dev/shm
@@ -281,17 +286,17 @@ def gunicorn():
                                 self, location
                             )
                             self.cfg.set("config", "./" + location)
-                            logger_info(f"gunicorn: used config {location}")
+                            logger_info(f"gunicorn: used {location}")
                             return
                         except KeyError:
                             pass
 
                     if gunicorn_vars:
-                        config.update(gunicorn_vars)
+                        sa_config.update(gunicorn_vars)
                         location = gunicorn_vars["config"]
-                        logger_info(f"gunicorn: used config {location} {config}")
+                        logger_info(f"gunicorn: used {location} {sa_config}")
 
-                    for k, v in config.items():
+                    for k, v in sa_config.items():
                         if k not in self.cfg.settings:
                             continue
                         try:
@@ -299,9 +304,6 @@ def gunicorn():
                         except Exception:
                             logger_info(f"gunicorn: Invalid value for {k}:{v}")
                             raise
-
-                    # if "print_config" in gunicorn_vars:
-                    #    gunicorn_vars["print_config"].lower() == "true" and logger_info( self.cfg)
 
                     try:
                         gunicorn_vars["print_config"] == "True" and logger_info(

--- a/py4web/server_adapters.py
+++ b/py4web/server_adapters.py
@@ -262,6 +262,12 @@ def gunicorn():
 
                     gunicorn_vars = self.get_gunicorn_vars()
 
+                    sa_show_msg = True
+                    if 'sa_show_msg' in gunicorn_vars:
+                        if gunicorn_vars['sa_show_msg'].lower() == 'false' :
+                             sa_show_msg = False
+                        del gunicorn_vars['sa_show_msg']
+
                     if 'use_native_config' in gunicorn_vars:
                           location=gunicorn_vars['use_native_config' ]
                           super().load_config_from_module_name_or_filename(location)

--- a/py4web/server_adapters.py
+++ b/py4web/server_adapters.py
@@ -142,6 +142,7 @@ def gunicorn():
 
         def run(self, app_handler):
             from gunicorn.app.base import Application
+            import re
 
             logger = None
 
@@ -191,7 +192,8 @@ def gunicorn():
                                     if not v or k == "bind":
                                         continue
                                     if v.startswith("{") and v.endswith("}"):
-                                        v = json.loads(v.replace("'", '"'))
+                                        vs =  re.sub(',\s*\}','}', v)
+                                        v = json.loads( vs.replace("'", "\"") )
                                     result[k] = None if v == "None" else v
                                 if result:
                                     print(f"gunicorn: read {env_file}")
@@ -205,7 +207,8 @@ def gunicorn():
                             if key == "bind":
                                 continue
                             if v.startswith("{") and v.endswith("}"):
-                                v = json.loads(v.replace("'", '"'))
+                                vs =  re.sub(',\s*\}','}', v)
+                                v = json.loads( vs.replace("'", "\"") )
                             result[key] = None if v == "None" else v
                     result["config"] = "environ"
                     return result

--- a/py4web/server_adapters.py
+++ b/py4web/server_adapters.py
@@ -128,9 +128,6 @@ def gunicorn():
     from gevent import local  # pip install gevent gunicorn
     import threading
 
-    # To use gevent monkey.patch_all()
-    # run ./py4web.py run apps -s gunicornGevent ...
-
     if isinstance(threading.local(), local.local):
         print("gunicorn: monkey.patch_all() applied")
 
@@ -139,6 +136,7 @@ def gunicorn():
 
         # ./py4web.py run apps -s gunicorn --watch=off --ssl_cert=cert.pem --ssl_key=key.pem -w 6 -L 20
         # ./py4web.py run apps -s gunicornGevent --watch=off --ssl_cert=cert.pem --ssl_key=key.pem -w 6 -L 20
+        # time seq 1 5000 | xargs -I % -P 0 curl http://localhost:8000/todo &>/dev/null
 
         def run(self, app_handler):
             from gunicorn.app.base import Application
@@ -225,59 +223,6 @@ def gunicorn():
                     return result
 
                 def load_config(self):
-
-                    """
-                    gunicorn.saenv
-
-                    # load conf from native_gunicorn
-                    use_native_config=python:example
-                    use_native_config=gunicorn.conf.py
-
-                    # or
-
-                    use_python_config=python:example
-                    use_python_config=gunicorn.conf.py
-
-                    # example
-                    # export GUNICORN_max_requests=1200
-                    export GUNICORN_worker_tmp_dir=/dev/shm
-
-                    # run as -s gunicornGevent
-                    #worker_class=gevent
-                    #worker_class=eventlet
-
-                    # run as -s gunicorn
-                    #worker_class=sync
-                    [hello any text]
-                    worker_class=gthread
-                    workers=4
-                    threads=8
-
-                    """
-
-                    # export GUNICORN_BACKLOG=4096
-                    # export GUNICORN_worker_connections=100
-
-                    # export GUNICORN_worker_class=sync
-                    # export GUNICORN_worker_class=gthread
-                    # export GUNICORN_worker_tmp_dir=/dev/shm
-                    # export GUNICORN_threads=8
-                    # export GUNICORN_timeout=10
-                    # export GUNICORN_max_requests=1200
-
-                    #
-                    # tested with ssep4w https://github.com/ali96343/lvsio
-                    #
-                    # To use gevent monkey.patch_all()
-                    # run ./py4web.py run apps -s gunicornGevent ......
-                    # export GUNICORN_worker_class=gevent
-                    # export GUNICORN_worker_class=gunicorn.workers.ggevent.GeventWorker
-                    #
-                    # pip install gunicorn[eventlet]
-                    # export GUNICORN_worker_class=eventlet
-                    #
-                    # time seq 1 5000 | xargs -I % -P 0 curl http://localhost:8000/todo &>/dev/null
-                    # time seq 1 5000 | xargs -I % -P 0 curl -k https://localhost:8000/todo &>/dev/null
 
                     gunicorn_vars = self.get_gunicorn_vars()
 

--- a/py4web/server_adapters.py
+++ b/py4web/server_adapters.py
@@ -129,18 +129,16 @@ def gunicorn():
     import threading
 
     # To use gevent monkey.patch_all()
-    # run ./py4web.py run apps -s gunicornGevent ......
+    # run ./py4web.py run apps -s gunicornGevent ...
+
     if isinstance(threading.local(), local.local):
         print("gunicorn: monkey.patch_all() applied")
 
     class GunicornServer(ServerAdapter):
         """ https://docs.gunicorn.org/en/stable/settings.html """
 
-        # https://pawamoy.github.io/posts/unify-logging-for-a-gunicorn-uvicorn-app/
-        # https://raw.githubusercontent.com/benoitc/gunicorn/master/examples/example_config.py
-
-        # ./py4web.py run apps -s gunicorn --watch=off --port=8000 --ssl_cert=cert.pem --ssl_key=key.pem -w 6 -L 20
-        # ./py4web.py run apps -s gunicornGevent --watch=off --port=8000 --ssl_cert=cert.pem --ssl_key=key.pem -w 6 -L 20
+        # ./py4web.py run apps -s gunicorn --watch=off --ssl_cert=cert.pem --ssl_key=key.pem -w 6 -L 20
+        # ./py4web.py run apps -s gunicornGevent --watch=off --ssl_cert=cert.pem --ssl_key=key.pem -w 6 -L 20
 
         def run(self, app_handler):
             from gunicorn.app.base import Application
@@ -218,7 +216,7 @@ def gunicorn():
                     gunicorn.saenv
 
                     # load conf from native_gunicorn
-                    usse_native_config=python:example
+                    use_native_config=python:example
                     use_native_config=gunicorn.conf.py
 
                     # example
@@ -260,6 +258,7 @@ def gunicorn():
                     # export GUNICORN_worker_class=eventlet
                     #
                     # time seq 1 5000 | xargs -I % -P 0 curl http://localhost:8000/todo &>/dev/null
+                    # time seq 1 5000 | xargs -I % -P 0 curl -k https://localhost:8000/todo &>/dev/null
 
                     def logger_info(msg="msg"):
                         logger and logger.info(str(msg))
@@ -292,10 +291,14 @@ def gunicorn():
                             logger_info(f"gunicorn: Invalid value for {k}:{v}")
                             raise
 
-                    if "print_config" in gunicorn_vars:
-                        gunicorn_vars["print_config"].lower() == "true" and logger_info(
-                            self.cfg
-                        )
+                    #if "print_config" in gunicorn_vars:
+                    #    gunicorn_vars["print_config"].lower() == "true" and logger_info( self.cfg)
+
+                    try:
+                        gunicorn_vars['print_config'] == 'True' and logger_info(self.cfg)
+                    except KeyError:
+                        pass
+
 
                 def load(self):
                     return app_handler

--- a/py4web/server_adapters.py
+++ b/py4web/server_adapters.py
@@ -195,6 +195,7 @@ def gunicorn():
                                     result[k] = None if v == 'None' else v
                                 if result:
                                     print(f"gunicorn: read {env_file}")
+                                    result['config'] = './' + env_file
                                     return result
                         except OSError as ex:
                             print(f"gunicorn: cannot read {env_file}; {ex}")
@@ -206,6 +207,7 @@ def gunicorn():
                             if v.startswith('{') and v.endswith('}'):
                                  v = json.loads( v.replace("'", "\"") )
                             result[key] = None if v == 'None' else v
+                    result['config'] = 'environ' 
                     return result
 
                 def load_config(self):
@@ -263,15 +265,16 @@ def gunicorn():
                     if 'use_native_config' in gunicorn_vars:
                           location=gunicorn_vars['use_native_config' ]
                           super().load_config_from_module_name_or_filename(location)
+                          self.cfg.set('config', './' + location)
                           print (f'gunicorn: used config {location}')
                           return
 
                     if gunicorn_vars:
                         config.update(gunicorn_vars)
-                        print("gunicorn: used config gunicorn.saenv", config)
+                        location = gunicorn_vars['config']
+                        print(f"gunicorn: used config {location}", config)
 
                     for k, v in config.items():
-                        #self.cfg.set(k, v)
                         if k not in self.cfg.settings:
                            continue
                         try:


### PR DESCRIPTION
to load gunicorn  config from a python file
or python module
It is necessary to write
export GUNICORN_use_native_config=myconf.py
export GUNICORN_use_native_config=python:mod_name

or write to gunicorn.saenv
export GUNICORN_use_native_config=myconf.py
export GUNICORN_use_native_config=python:mod_name
or
use_native_config=myconf.py
use_native_config=python:mod_name
