### PR TITLE
+ support unix:/socket to gunicorn

### DIFF
--- a/py4web/core.py
+++ b/py4web/core.py
@@ -2048,7 +2048,7 @@ def run(**kwargs):
                 'You have not set a dashboard password. Run "%s set_password" to do so.'
                 % PY4WEB_CMD
             )
-        elif "_dashboard" in Reloader.ROUTES and (not kwargs['host'].startswith('unix:')) :
+        elif "_dashboard" in Reloader.ROUTES and (not kwargs['host'].startswith('unix:/')) :
             click.echo(
                 f"Dashboard is at: http{'s' if kwargs.get('ssl_cert', None) else ''}://{kwargs['host']}:{kwargs['port']}/_dashboard"
             )

--- a/py4web/core.py
+++ b/py4web/core.py
@@ -2048,7 +2048,7 @@ def run(**kwargs):
                 'You have not set a dashboard password. Run "%s set_password" to do so.'
                 % PY4WEB_CMD
             )
-        elif "_dashboard" in Reloader.ROUTES:
+        elif "_dashboard" in Reloader.ROUTES and (not kwargs['host'].startswith('unix:')) :
             click.echo(
                 f"Dashboard is at: http{'s' if kwargs.get('ssl_cert', None) else ''}://{kwargs['host']}:{kwargs['port']}/_dashboard"
             )

--- a/py4web/gunicorn.rst
+++ b/py4web/gunicorn.rst
@@ -9,6 +9,8 @@ The gunicorn server starts in the usual way for the py4web
 
    $./py4web.py run apps -s gunicorn --watch=off
    $
+   $./py4web.py run apps -H 'unix:/tmp/p4w.sock' -w 4 -L 10
+   $
    $./py4web.py run apps -s gunicornGevent --watch=off
 
 
@@ -19,11 +21,11 @@ It is possible to use several methods to configure gunicorn options with py4web
 Let's show examples (go to py4web root dir)
 
 
-* set gunicorn options via py4web.py cmd-keys
+* set gunicorn options via py4web keys
 
- use: -H, -P, -w, -L, --ssl_cert, --ssl_key, -Q
+ use: -H, -P, -w, -L, --ssl_cert, --ssl_key , -Q
 
- ./py4web.py run apps -s gunicorn --watch=off -w 4 -H 192.168.1.161 -P 9000 -L 20 --ssl_cert=cert.pem --ssl_key=key.pem
+ ./py4web.py run apps -s gunicorn --watch=off -H 192.168.1.161 -P 9000 -L 20 --ssl_cert=cert.pem --ssl_key=key.pem
 
  with -L 10 we can see gunicorn options in server-py4web.log
 
@@ -83,8 +85,6 @@ Let's show examples (go to py4web root dir)
 
    # for use python-config-mod_name
    # use_python_config=python:mod_name
-   # or short 
-   # usepy=python:mod_name
 
 
 * set gunicorn options via python file myguni.conf.py
@@ -96,10 +96,10 @@ Let's show examples (go to py4web root dir)
  .. code:: bash
 
    $ # via env
-   $export GUNICORN_use_python_config=myguni.conf.py
+   $export GUNCORN_use_python_config=myguni.conf.py
    $ 
    $ # via gunicorn.saenv 
-   $echo use_python_config=myguni.conf.py >> gunicorn.saenv
+   $echo use_python_config=mmyguni.conf.py >> gunicorn.saenv
 
  ::
 
@@ -136,7 +136,7 @@ Let's show examples (go to py4web root dir)
   $  mkdir mod_name && cp myguni.conf.py mod_name/__init__.py
   $
   $ # via env
-  $export GUNICORN_use_python_config=python:mod_name
+  $export GUNCORN_use_python_config=python:mod_name
   $
   $ # via gunicorn.saenv
   $echo use_python_config=python:mod_name >> gunicorn.saenv
@@ -193,14 +193,14 @@ Let's show examples (go to py4web root dir)
  .. code:: bash
 
    export PY4WEB_LOGS=/tmp
-   p4w_todo_get() { time seq 1 500 | xargs -I % curl http://localhost:8000/todo &>/dev/null ;}
-   todotest() { for ((i=0; i < $1; i++)); do p4w_todo_get  & done  ;}
+   p4w_srv_test() { time seq 1 500 | xargs -I % curl http://localhost:8000/todo &>/dev/null ;}
+   gunitest() { for ((i=0; i < 20; i++)); do p4w_srv_test  & done  ;}
 
  ::
 
    $ ./py4web.py run apps -s gunicorn -L 10 --watch=off &
 
-   $ todotest 10
+   $ tguni
    $
    $ less /tmp/server-py4web.log
 

--- a/py4web/server_adapters.py
+++ b/py4web/server_adapters.py
@@ -131,12 +131,12 @@ def check_port(host="127.0.0.1", port=8000):
         except subprocess.CalledProcessError :
            pass
 
-    if host.startswith('unix:'):
+    if host.startswith('unix:/'):
         socket_path = host[5:]
         if os.path.exists(socket_path):
-            os_cmd ("ps au | grep py4web | grep -v grep")
-            os_cmd (f"ls -alF {socket_path}")
-            sys.exit(f"{socket_path} exists: can't run gunicorn")
+            os_cmd ("ps -ef | head -1; ps -ef | grep py4web | grep -v grep")
+            os_cmd (f"ls -alFi {socket_path}")
+            print (f"reopen {socket_path}")
         print (f'=== gunicorn listening at: {host} ===')
         return
 
@@ -174,7 +174,7 @@ def gunicorn():
 
             logger = None
 
-            sa_bind = self.host if self.host.startswith('unix:') else f"{self.host}:{self.port}"
+            sa_bind = self.host if self.host.startswith('unix:/') else f"{self.host}:{self.port}"
 
             sa_config = {
                 "bind": sa_bind, # f"{self.host}:{self.port}",


### PR DESCRIPTION
The patch allows bind gunicorn to unix socket

use:  ./py4web.py run apps  -H 'unix:/tmp/p4w.sock'  -w 4 -L 10

tested with nginx