### PR TITLE
Fix for Reflected XSS vulnerability in error_page() function of core.py

### DIFF
--- a/py4web/core.py
+++ b/py4web/core.py
@@ -35,6 +35,7 @@ import uuid
 import zipfile
 from collections import OrderedDict
 from contextlib import redirect_stderr, redirect_stdout
+import html as sanitize_html
 
 import portalocker
 from watchgod import awatch
@@ -1407,6 +1408,9 @@ ERROR_PAGES = {
 
 
 def error_page(code, button_text=None, href="#", color=None, message=None):
+    if button_text:
+        button_text = sanitize_html.escape(button_text)
+    href = sanitize_html.escape(href)
     message = http.client.responses[code].upper() if message is None else message
     color = (
         {"4": "#F44336", "5": "#607D8B"}.get(str(code)[0], "#2196F3")


### PR DESCRIPTION
There is a XSS Reflected in 'button_text' and 'href' parameters of error_page()

![image](https://github.com/web2py/py4web/assets/40671439/8a224d8f-99b0-4453-b917-39c25d0616f8)

![image](https://github.com/web2py/py4web/assets/40671439/7ab4bbfe-1b55-4ee3-807f-cb8a6350c9cc)

![image](https://github.com/web2py/py4web/assets/40671439/293c20f9-f5ea-4adb-af6b-58a89cbf37e4)

sanitizing those parameters address the issue.

![image](https://github.com/web2py/py4web/assets/40671439/02237d88-f31a-4928-a4ba-810b880e6d60)

![image](https://github.com/web2py/py4web/assets/40671439/d4221da2-9783-4c6b-8453-1c2d14ca6be0)
