### PR TITLE
Enable HTTPOnly for session cookie by default.

### DIFF
--- a/py4web/core.py
+++ b/py4web/core.py
@@ -700,6 +700,7 @@ class Session(Fixture):
             path="/",
             secure=self_local.secure,
             same_site=self.same_site,
+            httponly=True,
         )
 
     def get(self, key, default=None):


### PR DESCRIPTION
Hello.

I would like to propose enabling the 'HTTPOnly' attribute by default for session cookies. This is a best practice for security and helps mitigate the risk of the cookie being accessed in the event of an XSS vulnerability.

This is gonna be the result:
<img width="1106" alt="image" src="https://github.com/web2py/py4web/assets/40671439/f7fbf668-3068-407b-9376-ed3ee6abd513">

Greetings.