### PR TITLE
Catch initializing errors with the shell

### DIFF
--- a/apps/showcase/__init__.py
+++ b/apps/showcase/__init__.py
@@ -1,5 +1,6 @@
 import os
 import re
+import sqlite3
 
 from py4web import HTTP, action, request
 
@@ -23,7 +24,16 @@ from .examples.page_without_template import page_without_template
 from .examples.session_clear import session_clear
 from .examples.session_counter import session_counter
 from .examples.tagsinput_form import tagsinput_form
-from .examples.rest import rest
+try:
+    from .examples.rest import rest
+except sqlite3.OperationalError:
+    error_message = """
+    ** ERROR ** the examples db of the showcase app is not properly initialized.
+    You need to execute once 'py4web run apps' before using the shell with
+    py4web's showcase examples.
+    """ 
+    print(error_message)
+    exit(0)
 from .examples.rpc import rpc
 from .vue_components_examples.vue_file_uploader import vue_file_uploader
 from .vue_components_examples.vue_grid import vue_grid


### PR DESCRIPTION
If the shell is run and a `from apps.showcase.examples.common import db` issued (as explained in the docs) before running once a `py4web run apps`,  the db in the showcase/example is not created correctly - and a strange "sqlite3.OperationalError: no such table: person" error is shown.

It's not usual, but quite misleading. This explain it and simply show how to fix it.