### PR TITLE
Add `use_appname` parameter to the Form, Grid, and Auth classes

### DIFF
--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -277,6 +277,7 @@ class FormStyleFactory:
         deletable,
         noncreate,
         show_id,
+        use_appname,
         kwargs=None,
     ):
         kwargs = kwargs if kwargs else {}
@@ -284,6 +285,8 @@ class FormStyleFactory:
         kwargs["_accept-charset"] = "utf8"
         form_method = "POST"
         form_action = request.url.split(":", 1)[1]
+        if use_appname == False:
+            form_action = form_action.replace(f"/{request.app_name}", "")
         form_enctype = "multipart/form-data"
 
         if "_method" in kwargs:
@@ -696,6 +699,7 @@ class Form(object):
         signing_info=None,
         submit_value="Submit",
         show_id=False,
+        use_appname=None,
         **kwargs,
     ):
         self.param = Param(
@@ -732,6 +736,7 @@ class Form(object):
         self.lifespan = lifespan
         self.csrf_protection = csrf_protection
         self.show_id = show_id
+        self.use_appname = use_appname
         # initialized and can change
         self.vars = {}
         self.errors = {}
@@ -927,6 +932,7 @@ class Form(object):
                 self.deletable,
                 self.noncreate,
                 show_id=self.show_id,
+                use_appname=self.use_appname,
                 kwargs=self.kwargs,
             )
             for item in self.param.sidecar:

--- a/py4web/utils/grid.py
+++ b/py4web/utils/grid.py
@@ -318,6 +318,7 @@ class Grid:
         grid_class_style=GridClassStyle,
         T=lambda text: text,
         groupby=None,
+        use_appname=None,
         # deprecated
         fields=None,
         form_maker=Form,
@@ -351,6 +352,8 @@ class Grid:
             fullpath = request.fullpath.rstrip("/")
             if path == "index":
                 fullpath = fullpath[:-6]
+            if use_appname == False:
+                fullpath = fullpath.replace(f"/{request.app_name}", "")
             redirect(
                 f"{fullpath}/select"
                 + (f"?{request.query_string}" if request.query_string else "")
@@ -403,12 +406,16 @@ class Grid:
             header_elements=None,
             footer_elements=None,
             required_fields=required_fields or [],
+            use_appname=use_appname
         )
 
         #  instance variables that will be computed
         self.action = None
         self.current_page_number = None
         self.endpoint = request.fullpath[: -len(self.path)].rstrip("/")
+        if use_appname == False:
+            self.endpoint = self.endpoint.replace(f"/{request.app_name}", "")
+        print(f"endpoint = {self.endpoint}")
         self.hidden_fields = None
         self.form = None
         self.number_of_pages = None
@@ -940,12 +947,12 @@ class Grid:
         if orderby:
             if orderby == sort_order:
                 sort_query_parms["orderby"] = "~" + orderby
-                url = URL(self.endpoint, "select", vars=sort_query_parms)
+                url = URL(self.endpoint, "select", vars=sort_query_parms, use_appname=self.param.use_appname)
                 attrs = self.attributes_plugin.link(url=url)
                 col_header = A(heading, up, **attrs)
             else:
                 sort_query_parms["orderby"] = orderby
-                url = URL(self.endpoint, "select", vars=sort_query_parms)
+                url = URL(self.endpoint, "select", vars=sort_query_parms, use_appname=self.param.use_appname)
                 attrs = self.attributes_plugin.link(url=url)
                 col_header = A(
                     heading, dw if "~" + orderby == sort_order else "", **attrs
@@ -1130,7 +1137,7 @@ class Grid:
                 else "grid-pagination-button"
             )
             attrs = self.attributes_plugin.link(
-                url=URL(self.endpoint, "select", vars=pager_query_parms)
+                url=URL(self.endpoint, "select", vars=pager_query_parms, use_appname=self.param.use_appname)
             )
             pager.append(
                 A(

--- a/py4web/utils/grid.py
+++ b/py4web/utils/grid.py
@@ -613,6 +613,7 @@ class Grid:
                 formstyle=self.param.formstyle,
                 validation=self.param.validation,
                 show_id=self.param.show_id,
+                use_appname=self.param.use_appname,
                 **attrs,
             )
             if self.action == "new" and self.param.create:


### PR DESCRIPTION
Similarly to issues ancountered with URL generation including the `appname` as discussed in #910 , there is a related issue in Grid class. Grid generates several internal links and until now there are no options to avoid having the `appname` in those URLs. 

The PR propose here adds a parameter `use_appname` to the Grid signature (sorry Massimo!) and then modifies the internal logic inside the Grid class to use it, when generating internal links. This allows to avoid putting the `appname` in all the URLs, if not desired. 

The use case is well described in #910 , so I will not repeat it here. 

I tested the changes, and everything seems to be working as expected, but of course a second look would be very useful. Also, possibly the same functionality may be achieved in a different way.  