### PR TITLE
Patch URL helper to assume use_appname=False if the host is a FQDN

### DIFF
--- a/py4web/core.py
+++ b/py4web/core.py
@@ -37,6 +37,7 @@ import uuid
 import zipfile
 from collections import OrderedDict
 from contextlib import redirect_stderr, redirect_stdout
+from fqdn import FQDN
 
 import portalocker
 from watchgod import awatch
@@ -860,6 +861,8 @@ def URL(  # pylint: disable=invalid-name
     URL('a','b',vars=dict(x=1),scheme='https') -> https://{domain}/{script_name?}/{app_name?}/a/b?x=1
     URL('a','b',vars=dict(x=1),use_appname=False) -> /{script_name?}/a/b?x=1
     """
+    if FQDN(request.urlparts[1]).is_valid:
+        use_appname = False
     if use_appname is None:
         # force use_appname on domain-unmapped apps
         use_appname = not request.environ.get("HTTP_X_PY4WEB_APPNAME")

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ rocket3 >= 20230507.1
 yatl >= 20230507.3
 pydal >= 20240713.1
 watchgod >= 0.6
+fqdn
 
 # optional modules:
 # gunicorn


### PR DESCRIPTION
So - following the discussion in #911 - here is an idea for fixing the URL helper to _automagically_ choose the value of the `use_appname` parameter. 

Basically, I added one condition to check if there is a valid host being passed to the app. If the host (which I get from `request.urlparts[1]`) is a valid FQDN (i.e., a Fully Qualified Domain Name), the assumption is that `appname` should not be used in constructing the URL, and hence `use_appname` is set to `False`. 

There is of course the related import and updated `requirements.txt`. 