### PR TITLE
Auth TOTP fix

### DIFF
--- a/docs/chapter-13.rst
+++ b/docs/chapter-13.rst
@@ -159,17 +159,18 @@ username and password, and two factor authentication is enabled for the user, th
 
 There are a few Auth settings available to control how two factor authentication works.
 
-The follow can be specified on Auth instantiation:
+The following can be specified on Auth instantiation:
 
-- two_factor_required
-- two_factor_send
+- ``two_factor_required``
+- ``two_factor_send``
+- ``two_factor_validate``
 
 two_factor_required
 ^^^^^^^^^^^^^^^^^^^
 
 When you pass a method name to the ``two_factor_required`` parameter you are telling py4web to call that method to determine whether or not this login should
-be use or bypass two factor authentication.  If your method returns True, then this login requires two factor.  If it returns False, 
-two factor authentication is bypassed for this login.
+be use or bypass two factor authentication.  If your method returns True, then this login requires two factor.  If it returns False, two factor authentication 
+is bypassed for this login.
 
 Sample ``two_factor_required`` method
 
@@ -195,8 +196,8 @@ This example shows how to allow users that are on a specific network.
 two_factor_send
 ^^^^^^^^^^^^^^^
 
-When two factor authentication is active, py4web generates a 6 digit code (using random.randint) and sends it to you. How this code is sent, is up to you.
-The two_factor_send argument to the Auth class allows you to specify the method that sends the two factor code to the user.
+When two factor authentication is active, py4web can generate a 6 digit code (using random.randint) and makes it possible to send it to the user. How this code is 
+sent, is up to you. The ``two_factor_send`` argument to the Auth class allows you to specify the method that sends the two factor code to the user.
 
 This example shows how to send an email with the two factor code:
 
@@ -214,13 +215,53 @@ This example shows how to send an email with the two factor code:
            print(e)
        return code
 
-Notice that this method takes to arguments: the current user, and the code to be sent.
+Notice that this method takes two arguments: the current user, and the code to be sent.
 Also notice this method can override the code and return a new one.
 
 .. code:: python
 
    auth.param.two_factor_required = user_outside_network
    auth.param.two_factor_send = send_two_factor_email
+
+two_factor_validate
+^^^^^^^^^^^^^^^^^^^
+
+By default, py4web will validate the user input in the two factor form by comparing the number entered by the user with the code generated and sent using 
+``two_factor_send``. However, sometimes it may be useful to define a custom validation of this user-entered code. For instance, if one would like to use the 
+TOTP (or the Time-Based One-Time-Passwords) as the two factor authentication method, the validation requires comparing the code entered by the user with the 
+value generated at the same time at the server side. Hence, it is not sufficient to generate that value when showing the form (using for instance 
+``two_factor_send`` method), because by the time the user submits the form, the current valid value may already be different. Instead, this value should be 
+generated when validating the form submitted by the user. 
+
+To accomplish such custom validation, the ``two_factor_validate`` method is available. It takes one argument ``form``, which is the two factor authentication
+form. The primary use-case for this method is validation of time-based passwords.
+
+This example shows how to validate a time-based two factor code with an optional fallback to using the code returned by the ``two_factor_send`` method:
+
+.. code:: python
+
+   def validate_code(form):
+      # get the user id
+      user_id = auth.session.get("auth.2fa_user")
+
+      try:
+         # get the correct code from an external function
+         correct_code = generate_time_based_code(user_id)
+      except Exception as e:
+         # otherwise use the code that was returned by two_factor_send method
+         correct_code = auth.session.get("auth.2fa_code")
+      
+      # compare the value entered in the auth form with the correct code
+      if form.vars['authentication_code'] != correct_code:
+         form.errors['authentication_code'] = "Incorrect code."
+
+Notice that - if defined - this method is _always_ called to validate the two factor authentication form. It is up to you to decide what kind of validation it 
+does, but if it is used in conjunction with ``two_factor_send`` method, it also needs to be able to validate the user input against the code that was sent to 
+the user.
+
+.. code:: python
+
+   auth.param.two_factor_validate = validate_code
 
 two_factor_tries
 ^^^^^^^^^^^^^^^^
@@ -236,9 +277,11 @@ Once this is all setup, the flow for two factor authentication is:
 - present the login page
 - upon successful login and user passes two_factor_required
    - redirect to py4web auth/two_factor endpoint
-   - generate 6 digit verification code
-   - call two_factor_send to send the verification code to the user
+   - if ``two_factor_send`` method has been defined:
+      - generate 6 digit verification code 
+      - call ``two_factor_send`` to send the verification code to the user
    - display verification page where user can enter their code
+   - if ``two_factor_validate`` method has been defined - call it to validate the user-entered code
    - upon successful verification, take user to _next_url that was passed to the login page
 
 Important! If you filtered ``ALLOWED_ACTIONS`` in your app, make sure to whitelist the "two_factor" action so not to block the two factor API.


### PR DESCRIPTION
This PR proposes to add `two_factor_validate` callback to Auth in order to be able to handle custom two-factor code validation, and in particular handling the case of Time-Based One-Time-Passwords (TOTP). 

Two commits are proposed - one to modify the code, and the other to update the documentation. 