### PR TITLE
Fix #931 by using psutil to terminate

### DIFF
--- a/py4web/core.py
+++ b/py4web/core.py
@@ -1715,11 +1715,11 @@ def start_server(kwargs):
         main_process = psutil.Process()
         children = main_process.children(recursive=True)
         for child in children:
-            child.terminate()  # friendly termination
+            child.terminate()  # friendly termination (SIGTERM)
         _, still_alive = psutil.wait_procs(children, timeout=2)
         for child in still_alive:
-            child.kill()  # unfriendly termination
-        main_process.terminate()
+            child.kill()  # unfriendly termination (SIGKILL)
+        main_process.kill() # SIGKILL
 
     signal.signal(signal.SIGINT, kill_all)
 

--- a/py4web/core.py
+++ b/py4web/core.py
@@ -18,6 +18,7 @@ import http.cookies
 import importlib.machinery
 import importlib.util
 import inspect
+import io
 import json
 import logging
 import numbers
@@ -35,6 +36,7 @@ import urllib.parse
 import uuid
 import zipfile
 from collections import OrderedDict
+from contextlib import redirect_stderr, redirect_stdout
 
 import portalocker
 import psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ rocket3 >= 20241019.1
 yatl >= 20230507.3
 pydal >= 20241027.1
 watchgod >= 0.6
+psutil
 
 # optional modules:
 # gunicorn


### PR DESCRIPTION
This fixes
- #931

by using psutil to terminate the process tree. This should avoid any of the issues mentioned in https://discuss.python.org/t/terminateprocess-via-os-kill-on-windows/30882

i'm unsure if this will require extra work on https://github.com/nicozanf/py4web-pyinstaller as psutil includes native code (C)