### PR TITLE
Add more explanation about routing and add a section about custom error pages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -184,4 +184,5 @@ Many thanks to everyone who has contributed to the project, and especially:
 - `sugizo <https://github.com/sugizo>`__
 - `valq7711 <https://github.com/valq7711>`__
 - `Kevin Keller <https://github.com/Kkeller83>`__
+- `Krzysztof Socha <https://github.com/kszys>`__
 - Sam de Alfaro sam@dealfaro.com (logo design)


### PR DESCRIPTION
Following some issues with routing that I encountered, it appears that the documentation is _not exhaustive_ about how the routes work. This PR aims at adding a bit more explanation on what is and what is not possible with routes. 

Additionally, this PR adds a section about custom error pages, which have been described elsewhere, but not really covered by the documentation ATM. 