### PR TITLE
replaced deprecated datetime.utcnow() with datetime.now()

### DIFF
--- a/docs/chapter-06.rst
+++ b/docs/chapter-06.rst
@@ -711,7 +711,7 @@ it doesn't exist:
    @action.uses(db)
    def index():
        client_ip = request.environ.get('REMOTE_ADDR')
-       db.visit_log.insert(client_ip=client_ip, timestamp=datetime.utcnow())
+       db.visit_log.insert(client_ip=client_ip, timestamp=datetime.now())
        return "Your visit was stored in database"
 
 Notice that the database fixture defines (creates/re-creates) tables

--- a/py4web/core.py
+++ b/py4web/core.py
@@ -1168,7 +1168,7 @@ def get_error_snapshot(depth=5):
         etype = etype.__name__
 
     data = {}
-    data["timestamp"] = datetime.datetime.utcnow().isoformat().replace("T", " ")
+    data["timestamp"] = datetime.datetime.now().isoformat().replace("T", " ")
     data["python_version"] = sys.version
     platform_keys = [
         "machine",
@@ -1248,7 +1248,7 @@ class DatabaseErrorLogger:
                 app_name=app_name,
                 method=request.method,
                 path=request.path,
-                timestamp=datetime.datetime.utcnow(),
+                timestamp=datetime.datetime.now(),
                 client_ip=request.environ.get("REMOTE_ADDR"),
                 error=error_snapshot["exception_value"],
                 snapshot=error_snapshot,

--- a/py4web/utils/auth.py
+++ b/py4web/utils/auth.py
@@ -126,7 +126,7 @@ class AuthEnforcer(Fixture):
         # record the time of the latest activity for logged in user (with throttling)
         if not activity or time_now - activity > 6:
             self.auth.session["recent_activity"] = time_now
-        self.auth.session["recent_timestamp"] = datetime.datetime.utcnow().isoformat()
+        self.auth.session["recent_timestamp"] = datetime.datetime.now().isoformat()
         if callable(self.condition) and not self.condition(user):
             self.abort_or_redirect("not-authorized", "User not authorized")
 
@@ -424,7 +424,7 @@ class Auth(Fixture):
     @property
     def signature(self):
         """Returns a list of fields for a table signature"""
-        now = lambda: datetime.datetime.utcnow()
+        now = lambda: datetime.datetime.now()
         user = lambda s=self: s.user_id
         fields = [
             Field(
@@ -787,7 +787,7 @@ class Auth(Fixture):
                     past_passwords_hash=past_pwds
                 )
         num = db(db.auth_user.id == user.get("id")).update(
-            password=new_pwd, last_password_change=datetime.datetime.utcnow()
+            password=new_pwd, last_password_change=datetime.datetime.now()
         )
         return {"updated": num}
 

--- a/py4web/utils/dbstore.py
+++ b/py4web/utils/dbstore.py
@@ -19,7 +19,7 @@ class DBStore:
         self.table = db[name]
 
     def get(self, key):
-        db, table, now = self.db, self.table, datetime.utcnow()
+        db, table, now = self.db, self.table, datetime.now()
         row = db(table.rkey == key).select().first()
         if not row:
             return None
@@ -28,7 +28,7 @@ class DBStore:
         return row.rvalue
 
     def set(self, key, value, expiration=None):
-        db, table, now = self.db, self.table, datetime.utcnow()
+        db, table, now = self.db, self.table, datetime.now()
         db(table.expires_on < now).delete()
         row = db(table.rkey == key).select().first()
         expires_on = (


### PR DESCRIPTION
literally the title. 

Checked that .isoformat() still works