### PR TITLE
 Ensure fixture context always contains the key template_inject with a dict value

### DIFF
--- a/py4web/core.py
+++ b/py4web/core.py
@@ -514,10 +514,7 @@ class Flash(Fixture):
         output = context["output"]
         flash = self.local.flash or ""
         if isinstance(output, dict):
-            if "template_inject" in context:
-                context["template_inject"]["flash"] = flash
-            else:
-                context["template_inject"] = dict(flash=flash)
+            context["template_inject"]["flash"] = flash
         elif self.local.flash is not None:
             response.headers.setdefault("component-flash", json.dumps(flash))
 
@@ -611,7 +608,7 @@ class Template(Fixture):
         ctx = dict(request=request)
         ctx.update(HELPERS)
         ctx.update(URL=URL)
-        ctx.update(context.get("template_inject", {}))
+        ctx.update(context["template_inject"])
         ctx.update(output)
         ctx["__vars__"] = output
         app_folder = os.path.join(os.environ["PY4WEB_APPS_FOLDER"], request.app_name)
@@ -993,6 +990,7 @@ class action:  # pylint: disable=invalid-name
                     "output": None,
                     "exception": None,
                     "processed": processed,
+                    "template_inject": {},
                 }
                 try:
                     for fixture in fixtures:

--- a/py4web/utils/auth.py
+++ b/py4web/utils/auth.py
@@ -339,7 +339,7 @@ class Auth(Fixture):
 
     def on_success(self, context):
         if self.inject:
-            context["template_inject"] = {"user": self.get_user()}
+            context["template_inject"]["user"] = self.get_user()
 
     def define_tables(self):
         """Defines the auth_user table"""

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -2,6 +2,7 @@
 import copy
 import multiprocessing
 import os
+import sys
 import threading
 import time
 import unittest
@@ -18,7 +19,18 @@ os.environ["PY4WEB_APPS_FOLDER"] = os.path.sep.join(
 )
 
 SECRET = str(uuid.uuid4())
-db = DAL("sqlite://storage_%s" % uuid.uuid4(), folder="/tmp/")
+if sys.platform == "win32":
+    path = "./tmp/"
+else:
+    path = "/tmp/"
+
+try:
+    os.mkdir(path)
+except Exception:
+    pass
+with open(path + "sql.log", "w"):
+    pass
+db = DAL("sqlite://storage_%s" % uuid.uuid4(), folder=path)
 db.define_table("thing", Field("name"))
 session = Session(secret=SECRET)
 cache = Cache()

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -9,7 +9,7 @@ PATH = os.path.join(os.path.dirname(__file__), "templates")
 class TemplateTest(unittest.TestCase):
     def test_template(self):
         t = Template("index.html", path=PATH)
-        context = dict(output=dict(n=3))
+        context = dict(output=dict(n=3), template_inject={})
         t.on_success(context)
         output = context["output"]
         self.assertEqual(output, "0,1,2.\n")


### PR DESCRIPTION
This means various fixtures won't have to check if it exists.

Solves the issue that Auth overwrites the entire template_inject dict when Auth.inject is true.

follow-up/related ideas: 
- Unify the various things being added to the render context (request, HELPERS, URL), by adding them to template_inject from the start
- Allow a way to define template helper functions without having to Inject() in each controller, using a decorator which stores them in a global variable added to template_inject like this
   ```py
   @template_helper
   def myhelper():
       return "test"
   ```