### PR TITLE
Add "postrequisites" to fixtures - the inverse of a prerequisite

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ rocket3 >= 20241019.1
 yatl >= 20230507.3
 pydal >= 20241027.1
 watchgod >= 0.6
+graphlib_backport>=1.0;python_version<"3.9"
 
 # optional modules:
 # gunicorn

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -2,6 +2,7 @@
 import copy
 import multiprocessing
 import os
+import sys
 import threading
 import time
 import unittest
@@ -18,7 +19,18 @@ os.environ["PY4WEB_APPS_FOLDER"] = os.path.sep.join(
 )
 
 SECRET = str(uuid.uuid4())
-db = DAL("sqlite://storage_%s" % uuid.uuid4(), folder="/tmp/")
+if sys.platform == "win32":
+    path = "./tmp/"
+else:
+    path = "/tmp/"
+
+try:
+    os.mkdir(path)
+except Exception:
+    pass
+with open(path + "sql.log", "w"):
+    pass
+db = DAL("sqlite://storage_%s" % uuid.uuid4(), folder=path)
 db.define_table("thing", Field("name"))
 session = Session(secret=SECRET)
 cache = Cache()


### PR DESCRIPTION
A postrequisite is a fixture dependency which specifies that the postrequisite should run after the source fixture.
This in turn results in the postrequisite running before the source fixture for `on_success`

If i write a fixture A, which only has a `on_succes` that should run after the `on_success` of B, i can't make B a `__prerequisites__` as those are sorted for `on_request`. This means as a prerequisite, `B.on_success` will run after my `A.on_success`, not before.

`__postrequisites__` simply reverses this relation. B being in `__postrequisites__` on A is the same a A being in the `__prerequisites__` of B - and in fact, internally this is how postrequisites are represented while building the Directed Acyclic Graph.

This PR switches the custom topological sort to use `graphlib` instead, as `graphlib` detects cycles. `graphlib` is a new stdlib module since python 3.9, so `graphlib-backport` is added as a dependency for compatability with older python versions.
