### PR TITLE
Update dockerfile to support newer Ubuntu distributions

### DIFF
--- a/deployment_tools/docker/Dockerfile
+++ b/deployment_tools/docker/Dockerfile
@@ -1,21 +1,21 @@
-
 FROM ubuntu:latest
 
 ARG user=py4web
 
 RUN apt update && \
-    apt install -y git python3 python3-pip memcached && \
+    apt install -y git python3 python3-pip python3-venv memcached && \
     service memcached restart && \
     groupadd -r $user && \
-    useradd -m -r -g $user $user && \
-    python3 -m pip install -U py4web
+    useradd -m -r -g $user $user
 
 USER $user
+WORKDIR /home/$user/
 
-RUN cd /home/$user/ && py4web setup --yes apps
+RUN python3 -m venv venv && \
+    . venv/bin/activate && \
+    pip install -U py4web && \
+    py4web setup --yes apps
 
 EXPOSE 8000
 
-WORKDIR /home/$user/
-
-CMD py4web run --password_file password.txt --host 0.0.0.0 --port 8000 apps
+CMD . venv/bin/activate && py4web run --password_file password.txt --host 0.0.0.0 --port 8000 apps


### PR DESCRIPTION
When deploying the sample container I was getting this error.

> To install Python packages system-wide, try apt install python3-xyz, where xyz is the package you are trying to install. If you wish to install a non-Debian-packaged Python package, create a virtual environment using python3 -m venv path/to/venv. Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make sure you have python3-full installed. If you wish to install a non-Debian packaged Python application, it may be easiest to use pipx install xyz, which will manage a virtual environment for you. Make sure you have pipx installed. See /usr/share/doc/python3.12/README.venv for more information.note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.hint: See PEP 668 for the detailed specification

I've updated the Dockerfile to meet this requirement.

With these changes I was able to launch the container.
