### PR TITLE
Allow to check across multiple domains in URL validation

### DIFF
--- a/py4web/core.py
+++ b/py4web/core.py
@@ -912,10 +912,16 @@ def URL(  # pylint: disable=invalid-name
     if scheme is not False:
         original_url = request.environ.get("HTTP_ORIGIN") or request.url
         orig_scheme, _, domain = original_url.split("/", 3)[:3]
-        expected_domain = os.environ.get("PY4WEB_DOMAIN")
-        if expected_domain and domain != expected_domain:
-            logging.warning(f"Possible cache poisoning blocked: url={original_url}")
-            domain = expected_domain
+        expected_domains = [
+            domain_item.strip()
+            for domain_item in os.environ.get("PY4WEB_DOMAINS", "").split(",")
+            if domain_item
+        ]
+        if expected_domains and domain not in expected_domains:
+            logging.warning(
+                "Possible cache poisoning blocked: url=%s", original_url
+            )
+            domain = expected_domains[0]
         if scheme is True:
             scheme = orig_scheme
         elif scheme is None:


### PR DESCRIPTION
The recent commit [0b83a76](https://github.com/web2py/py4web/commit/0b83a76a259f3f8a69b682447aa6d43b3664fce3) introduced the ability to validate generated URLs against a specific domain.

This PR expands that functionality by allowing validation against multiple domains, providing greater flexibility for developers working with multi-domain environments.