### PR TITLE
Added support to choose between Google Recaptcha V2 and V3

### DIFF
--- a/py4web/utils/auth.py
+++ b/py4web/utils/auth.py
@@ -1661,12 +1661,25 @@ class DefaultAuthForms:
         user = None
         next_url = prevent_open_redirect(request.query.get("next"))
         self.auth.session["_next_login"] = next_url
+        
         if form.submitted:
+            # First, check for errors in the form  
+            if form.errors:
+                # Stops processing and returns the form with errors  
+                return form  
+
+            # If there are no errors, continue with the login process.
             user, error = self.auth.login(
-                form.vars.get("email", ""), form.vars.get("password", "")
+                form.vars.get("email", ""), 
+                form.vars.get("password", "")
             )
             form.accepted = not error
-            form.errors["password"] = error
+
+            # Stops processing if there is a login error
+            if error:
+                form.errors["password"] = error
+                return form  
+            
         if user:
             #  We will process two_factor if two_factor_send is defined and either
             #  - No two_factor_required defined

--- a/py4web/utils/auth.py
+++ b/py4web/utils/auth.py
@@ -1657,7 +1657,6 @@ class DefaultAuthForms:
             fields,
             submit_value=button_name,
             formstyle=self.formstyle,
-            form_name="form_auth",
         )
         user = None
         next_url = prevent_open_redirect(request.query.get("next"))

--- a/py4web/utils/auth.py
+++ b/py4web/utils/auth.py
@@ -1657,6 +1657,7 @@ class DefaultAuthForms:
             fields,
             submit_value=button_name,
             formstyle=self.formstyle,
+            form_name="form_auth",
         )
         user = None
         next_url = prevent_open_redirect(request.query.get("next"))
@@ -1697,6 +1698,7 @@ class DefaultAuthForms:
                     redirect(URL(f"{self.auth.route}/two_factor"))
             self.auth.store_user_in_session(user["id"])
             self._postprocessing("login", form, user)
+            
 
         if self.auth.allows("register"):
             form.param.sidecar.append(


### PR DESCRIPTION
Hello,

I've added support to choose between Google reCAPTCHA V2 and V3. To make a selection, you need to specify the correct keys and set the version (v2 or v3).

I made a small modification in `auth.py` because it was not stopping user login if the CAPTCHA was or incorrect. The now first checks for errors, including the reCAPTCHA challenge. If there is an error, it stops; if there are no errors, it will attempt to log in.

In `recaptcha.py`, I've added logic to automatically select either reCAPTCHA V2 or V3.

example:

common.py
```
from py4web.utils.recaptcha import ReCaptcha
#for recaptcha v3
recaptcha = ReCaptcha(settings.RECAPTCHA_API_KEY_V3, settings.RECAPTCHA_API_SECRET_V3, "v3")
or 
#for recaptcha v2
recaptcha = ReCaptcha(settings.RECAPTCHA_API_KEY_V2, settings.RECAPTCHA_API_SECRET_V2, "v2")

# in the section that auth is defined
auth.extra_form_fields = {"login": [recaptcha.field], "register": [recaptcha.field], "request_reset_password": [recaptcha.field], }



auth.enable(uses=(session, T, db, recaptcha.fixture), env=dict(T=T))
```

auth.html
```
  [[try:]]
  [[=form]]
  [[except:]]
  [[pass]]
  [[=recaptcha]]

```

A try/except block must be implemented when the captcha is enabled (at least for now) because, when the login is successful, it throws the error: NameError: name 'form' is not defined. Using a try/except works as a patch, and the login functions normally. 

Greetings.
Chris.


