### PR TITLE
Added support for hCaptcha in Auth form

### DIFF
--- a/py4web/utils/hcaptcha.py
+++ b/py4web/utils/hcaptcha.py
@@ -1,0 +1,92 @@
+import requests
+from yatl.helpers import XML
+
+from py4web.core import Field, Fixture, request
+
+
+class hcaptcha_fixture(Fixture):
+    def __init__(self, site_key, secret_key):
+        self.site_key = site_key
+        self.secret_key = secret_key
+
+        Fixture.__init__(self)
+
+    def on_request(self, context):
+        value = request.POST.get("h-captcha-response")
+        if value:
+            request.POST["h_captcha_response"] = value
+            del request.POST["h-captcha-response"]
+
+    def on_success(self, context):
+        if context:
+            hcaptcha_script = "".join(
+                map(
+                    lambda line: line.strip(),
+                    """<script>
+                    
+            hcaptcha_div = document.createElement('div');
+            input = document.getElementById("no_table_h_captcha_response");
+            let label = document.querySelector('label[for="no_table_h_captcha_response"]');
+            label.hidden = true;
+          
+            input.hidden = true;
+            hcaptcha_div.setAttribute("data-sitekey", "%s");
+            hcaptcha_div.classList.add("h-captcha");
+            var form =  document.querySelector("form");
+            form.appendChild(hcaptcha_div);
+            var button = form.querySelector("input[type=submit]");
+             if (window.location.href.endsWith('/auth/register')) {
+                form.insertBefore(hcaptcha_div, form.childNodes[5]);
+                }
+              else if (window.location.href.endsWith('/auth/request_reset_password')) {
+                form.insertBefore(hcaptcha_div, form.childNodes[2]);
+                }
+              else {
+                form.insertBefore(hcaptcha_div, form.childNodes[4]);
+              }
+            window.hcaptcha_submit = function(token){ form.submit(); };
+            </script>
+            <script src="https://js.hcaptcha.com/1/api.js" async defer></script>
+            """.split(
+                        "\n"
+                    ),
+                )
+            )
+            
+            if context["output"] is None:
+                context["output"] = {}
+            context["output"]["hcaptcha"] = XML(hcaptcha_script % self.site_key)
+        
+
+
+class Hcaptcha:
+    def __init__(self, site_key, secret_key):
+        self.site_key = site_key
+        self.secret_key = secret_key
+
+
+    @property
+    def fixture(self):
+        return hcaptcha_fixture(self.site_key, self.secret_key)
+
+    @property
+    def field(self):
+        return Field("h_captcha_response", "hidden", requires=self.validator)
+
+    def validator(self, value, _):
+        print(value)
+        print(self.secret_key)
+        # Build payload with secret key and token.
+        data = {"secret":self.secret_key, "response": value}
+
+        # Make POST request with data payload to hCaptcha API endpoint.
+        res = requests.post(url="https://hcaptcha.com/siteverify", data=data)
+        print(res.text)
+        try:
+            
+            if res.json()["success"]:
+                return (True, None)
+            return (False, "Invalid Hcaptcha value")
+        except Exception as exc:
+            print(exc)
+            return (False, str(exc))


### PR DESCRIPTION
Hello,

I've added support for hCaptcha in auth forms. It works identical than reCAPTCHA.

example:

common.py
```
from py4web.utils.hcaptcha import Hcaptcha
hcaptcha = Hcaptcha(settings.HCAPTCHA_SITE_KEY, settings.HCAPTCHA_SECRET_KEY)

#in the section that auth is defined
auth.extra_form_fields = {"login": [hcaptcha.field], "register": [hcaptcha.field], "request_reset_password": [hcaptcha.field], }

auth.enable(uses=(session, T, db, hcaptcha.fixture),env=dict(T=T))
```

auth.html
```
  [[try:]]
  [[=form]]
  [[except:]]
  [[pass]]
  [[=hcaptcha]]
```
A try/except block must be implemented when the captcha is enabled (at least for now) because, when the login is successful, it throws the error: NameError: name 'form' is not defined. Using a try/except works as a patch, and the login functions normally.

screenshots:
Login
<img width="367" alt="imagen" src="https://github.com/user-attachments/assets/51656d77-1796-4727-a744-1cb91581359b" />

Password reset
<img width="377" alt="imagen" src="https://github.com/user-attachments/assets/933a6821-3c73-404e-ba1c-d9ccf302cf4e" />

Sing up with error values:
<img width="334" alt="imagen" src="https://github.com/user-attachments/assets/c6e73cfb-bb6d-4d5d-8429-906998a417f1" />



Greetings.
Chris.
