### PR TITLE
Added documentation to enable CAPTCHA on login

### DIFF
--- a/apps/_documentation/static/en/chapter-13.html
+++ b/apps/_documentation/static/en/chapter-13.html
@@ -69,6 +69,12 @@
 <li class="toctree-l4"><a class="reference internal" href="#two-factor-send">two_factor_send</a></li>
 <li class="toctree-l4"><a class="reference internal" href="#two-factor-validate">two_factor_validate</a></li>
 <li class="toctree-l4"><a class="reference internal" href="#two-factor-tries">two_factor_tries</a></li>
+
+</ul>
+</li>
+<li class="toctree-l3"><a class="reference internal" href="#captcha">Authentication with CAPTCHA</a><ul>
+  <li class="toctree-l4"><a class="reference internal" href="#reCAPTCHA">reCAPTCHA</a></li>
+  <li class="toctree-l4"><a class="reference internal" href="#hCAPTCHA">hCAPTCHA</a></li>
 </ul>
 </li>
 <li class="toctree-l3"><a class="reference internal" href="#auth-plugins">Auth Plugins</a><ul>
@@ -400,7 +406,9 @@ will fail if <code class="docutils literal notranslate"><span class="pre">two_fa
 <p>Important! If you filtered <code class="docutils literal notranslate"><span class="pre">ALLOWED_ACTIONS</span></code> in your app, make sure to whitelist the “two_factor” action
 so not to block the two factor API.</p>
 </section>
-</section>
+<hr>
+
+
 <section id="auth-plugins">
 <h3>Auth Plugins<a class="headerlink" href="#auth-plugins" title="Link to this heading"></a></h3>
 <p>Plugins are defined in “py4web/utils/auth_plugins” and they have a
@@ -490,7 +498,127 @@ You will also have to register your OAuth2 redirect URI in your created applicat
 Discord username as the first name and discriminator as the last name.</p>
 </div>
 </section>
+<hr>
+<section id="captcha">
+  <h3>Authentication with CAPTCHA<a class="headerlink" href="#captcha" title="Link to this heading"></a></h3>
+
+  <p>CAPTCHAs are essential security measures that prevent automated bot abuse on public forms. To implement Google reCAPTCHA or hCAPTCHA in your authentication form, follow these steps:</p>
+
+  <section id="reCAPTCHA">
+    <h4>Enabling reCAPTCHA<a class="headerlink" href="#reCAPTCHA" title="Link to this heading"></a></h4>
+    <p>in <code class="docutils literal notranslate">settings.py</code> add your keys:</p>
+    <div class="highlight-python notranslate">
+      <div class="highlight">
+        <pre>
+          RECAPTCHA_API_SECRET_V3 = "your_recaptcha_secret_key_v3"
+          RECAPTCHA_API_KEY_V3 = "your_recaptcha_site_key_v3"
+           
+          RECAPTCHA_API_KEY_V2 = "your_recaptcha_site_key_v2"
+          RECAPTCHA_API_SECRET_V2 = "your_recaptcha_secret_key_v2"
+  
+      </pre>
+      </div>
+    </div>
+    
+    <p>in <code class="docutils literal notranslate">common.py</code> add:</p>
+  
+    <div class="highlight-python notranslate">
+      <div class="highlight">
+        <pre>
+        #import the functionality
+        <span class="kn">from</span> <span class="nn">. </span><span class="kn">import</span> settings
+        <span class="kn">from</span> <span class="nn">py4web.utils.recaptcha </span><span class="kn">import</span> ReCaptcha
+  
+        # <span class="s2">for recaptcha v3</span> 
+        <span class="nf">recaptcha</span> = <span class="nn">ReCaptcha</span>(<span class="nd">settings</span>.RECAPTCHA_API_KEY_V3, <span class="nd">settings</span>.RECAPTCHA_API_SECRET_V3, "v3")
+        or 
+        # <span class="s2">for recaptcha v2</span> 
+        <span class="nf">recaptcha</span> = <span class="nn">ReCaptcha</span>(<span class="nd">settings</span>.RECAPTCHA_API_KEY_V2, <span class="nd">settings</span>.RECAPTCHA_API_SECRET_V2, "v2")
+  
+  
+        # in the section that auth is defined
+        # Example:
+        auth = Auth(session, db, define_tables=False)
+  
+        # Add this line at the end of auth declaration to enable recaptcha on login, register and request_reset_password forms.
+        # or enable it on the action that you want by especifying the action name
+        
+        #Example:
+  
+        auth.extra_form_fields = {"login": [<span class="nf">recaptcha</span>.field], "register": [<span class="nf">recaptcha</span>.field], "request_reset_password": [<span class="nf">recaptcha</span>.field], }
+  
+  
+        #In section where auth is enabled, add the recaptcha fixture
+        # Example:
+  
+        # #######################################################
+        # Enable authentication
+        # #######################################################
+        auth.enable(uses=(session, T, db, <span class="nf">recaptcha</span>.fixture),env=dict(T=T))
+  
+      </pre>
+      
+    </div>
+    
+    </div>
+    <p>
+      After completing these steps, the reCAPTCHA field will be added to the login, register, and request_reset_password forms.
+    </p>
+  </section>
+  <hr>
+  <section id="hCAPTCHA">
+    <h4>Enabling hCAPTCHA<a class="headerlink" href="#hCAPTCHA" title="Link to this heading"></a></h4>
+    <p>in <code class="docutils literal notranslate">settings.py</code> add your HCAPTCHA_SITE_KEY and HCAPTCHA_SECRET_KEY:</p>
+    <div class="highlight-python notranslate">
+      <div class="highlight">
+        <pre>
+          HCAPTCHA_SITE_KEY = "your_hcaptcha_site_key"
+          HCAPTCHA_SECRET_KEY = "your_hcaptcha_secret_key"
+      </pre>
+      </div>
+    </div>
+    <p>in <code class="docutils literal notranslate">common.py</code> add:</p>
+    <div class="highlight-python notranslate">
+      <div class="highlight">
+        <pre>
+        #import the functionality
+        <span class="kn">from</span> <span class="nn">. </span><span class="kn">import</span> settings
+        <span class="kn">from</span> <span class="nn">py4web.utils.hcaptcha </span><span class="kn">import</span> Hcaptcha
+  
+        <span class="nf">hcaptcha</span> = <span class="nn">Hcaptcha</span>(<span class="nd">settings</span>.HCAPTCHA_SITE_KEY, <span class="nd">settings</span>.HCAPTCHA_SECRET_KEY)
+        
+  
+        # in the section that auth is defined
+        # Example:
+        auth = Auth(session, db, define_tables=False)
+  
+        # Add this line at the end of auth declaration to enable hcaptcha on login, register and request_reset_password forms.
+        # or enable it on the action that you want by especifying the action name
+        
+        #Example:
+  
+        auth.extra_form_fields = {"login": [<span class="nf">hcaptcha</span>.field], "register": [<span class="nf">hcaptcha</span>.field], "request_reset_password": [<span class="nf">hcaptcha</span>.field], }
+  
+  
+        #In section where auth is enabled, add the hcaptcha fixture
+        # Example:
+  
+        # #######################################################
+        # Enable authentication
+        # #######################################################
+        auth.enable(uses=(session, T, db, <span class="nf">hcaptcha</span>.fixture),env=dict(T=T))
+  
+      </pre>
+      
+    </div>
+    
+    </div>
+    <p>
+      After completing these steps, the hCAPTCHA field will be added to the login, register, and request_reset_password forms.
+    </p>
+  </section>  
 </section>
+<hr>
 <section id="auth-api-plugins">
 <h3>Auth API Plugins<a class="headerlink" href="#auth-api-plugins" title="Link to this heading"></a></h3>
 <p>There are two types of web APIs, those called by the browser for example by a single page web app,


### PR DESCRIPTION
Hello I've added the documentation to enable reCAPTCHA or hCAPTCHA in auth forms based on the previous PR: 

- https://github.com/web2py/py4web/pull/962(url)
- https://github.com/web2py/py4web/pull/961(url)

The documentation looks like this:
menu
<img width="300" alt="imagen" src="https://github.com/user-attachments/assets/c7d7586b-ea17-47a8-90e2-11e6d9bb3c76" />

content
<img width="1138" alt="imagen" src="https://github.com/user-attachments/assets/e6c32e82-09a8-4afa-a46f-903f715d013c" />

<img width="1156" alt="imagen" src="https://github.com/user-attachments/assets/7c6303f3-baec-4c3c-956a-baed0112ae25" />

I hope this can help.
Greetings
