### PR TITLE
Fix errorlevel set for single apps

### DIFF
--- a/py4web/server_adapters/logging_utils.py
+++ b/py4web/server_adapters/logging_utils.py
@@ -45,6 +45,7 @@ def make_logger(name, loggers_info):
     # This ensures that all messages at or above this level are processed by the logger,
     # and not filtered out before reaching the handlers.
     root.setLevel(min_level)
+    root.propagate = False  # Prevent double logging with same name to root logger
     return root
 
 

--- a/py4web/server_adapters/logging_utils.py
+++ b/py4web/server_adapters/logging_utils.py
@@ -24,19 +24,27 @@ def make_logger(name, loggers_info):
     root = logging.getLogger(name)
     list(map(root.removeHandler, root.handlers))
     list(map(root.removeFilter, root.filters))
+    min_level = logging.CRITICAL
     for logger in loggers_info:
         logger += ":stderr" if logger.count(":") == 0 else ""
         logger += ":" if logger.count(":") == 1 else ""
         level, filename, formatter = logger.split(":", 2)
         if not formatter:
             formatter = default_formatter
+        handler_level = getattr(logging, level.upper(), logging.DEBUG)
+        if handler_level < min_level:
+            min_level = handler_level
         if filename in ("stdout", "stderr"):
             handler = logging.StreamHandler(getattr(sys, filename))
         else:
             handler = logging.FileHandler(filename)
         handler.setFormatter(logging.Formatter(formatter))
-        handler.setLevel(getattr(logging, level.upper(), "DEBUG"))
+        handler.setLevel(handler_level)
         root.addHandler(handler)
+    # Set the logger's level to the lowest handler level found.
+    # This ensures that all messages at or above this level are processed by the logger,
+    # and not filtered out before reaching the handlers.
+    root.setLevel(min_level)
     return root
 
 


### PR DESCRIPTION
(AI generated)

This PR ensures that the logger's level is set to the lowest handler level specified in the `LOGGERS` configuration.   Previously, even if a handler was set to `DEBUG`, the logger itself could filter out lower-level messages (like `DEBUG`), resulting in missing log output.   By explicitly setting `root.setLevel(min_level)`, all messages at or above the configured level are processed and passed to the handlers as expected.