### PR TITLE
Better jsdoc types and ignores in utils.js (passes vscode js checking) and some improvements

### DIFF
--- a/apps/_dashboard/static/js/utils.js
+++ b/apps/_dashboard/static/js/utils.js
@@ -272,8 +272,14 @@ Q.throttle = (callback, delay) => {
     return throttledEventHandler;
 };
 
-// parse a comma separated list of strings which may be quoted
+/**
+ * parse a comma separated list of strings which may be quoted
+ * @param {string} line
+ * @returns
+ */
 Q.parse_list = function (line) {
+    // handle empty string case
+    if (line.length === 0) return [];
     let a = [],
         i = 0,
         s = "",
@@ -314,9 +320,9 @@ Q.parse_list = function (line) {
 Q.tags_input = function (elem_arg, options) {
     /** @type {HTMLInputElement} */
     let elem;
-    if (typeof elem === "string") {
+    if (typeof elem_arg === "string") {
         // @ts-ignore
-        elem = Q(elem)[0];
+        elem = Q(elem_arg)[0];
         if (!elem) {
             console.log("Q.tags_input: elem " + elem_arg + " not found");
             return;

--- a/apps/_scaffold/static/js/utils.js
+++ b/apps/_scaffold/static/js/utils.js
@@ -272,8 +272,14 @@ Q.throttle = (callback, delay) => {
     return throttledEventHandler;
 };
 
-// parse a comma separated list of strings which may be quoted
+/**
+ * parse a comma separated list of strings which may be quoted
+ * @param {string} line
+ * @returns
+ */
 Q.parse_list = function (line) {
+    // handle empty string case
+    if (line.length === 0) return [];
     let a = [],
         i = 0,
         s = "",
@@ -314,9 +320,9 @@ Q.parse_list = function (line) {
 Q.tags_input = function (elem_arg, options) {
     /** @type {HTMLInputElement} */
     let elem;
-    if (typeof elem === "string") {
+    if (typeof elem_arg === "string") {
         // @ts-ignore
-        elem = Q(elem)[0];
+        elem = Q(elem_arg)[0];
         if (!elem) {
             console.log("Q.tags_input: elem " + elem_arg + " not found");
             return;

--- a/apps/fadebook/static/js/utils.js
+++ b/apps/fadebook/static/js/utils.js
@@ -272,8 +272,14 @@ Q.throttle = (callback, delay) => {
     return throttledEventHandler;
 };
 
-// parse a comma separated list of strings which may be quoted
+/**
+ * parse a comma separated list of strings which may be quoted
+ * @param {string} line
+ * @returns
+ */
 Q.parse_list = function (line) {
+    // handle empty string case
+    if (line.length === 0) return [];
     let a = [],
         i = 0,
         s = "",
@@ -314,9 +320,9 @@ Q.parse_list = function (line) {
 Q.tags_input = function (elem_arg, options) {
     /** @type {HTMLInputElement} */
     let elem;
-    if (typeof elem === "string") {
+    if (typeof elem_arg === "string") {
         // @ts-ignore
-        elem = Q(elem)[0];
+        elem = Q(elem_arg)[0];
         if (!elem) {
             console.log("Q.tags_input: elem " + elem_arg + " not found");
             return;

--- a/apps/showcase/static/js/utils.js
+++ b/apps/showcase/static/js/utils.js
@@ -272,8 +272,14 @@ Q.throttle = (callback, delay) => {
     return throttledEventHandler;
 };
 
-// parse a comma separated list of strings which may be quoted
+/**
+ * parse a comma separated list of strings which may be quoted
+ * @param {string} line
+ * @returns
+ */
 Q.parse_list = function (line) {
+    // handle empty string case
+    if (line.length === 0) return [];
     let a = [],
         i = 0,
         s = "",
@@ -314,9 +320,9 @@ Q.parse_list = function (line) {
 Q.tags_input = function (elem_arg, options) {
     /** @type {HTMLInputElement} */
     let elem;
-    if (typeof elem === "string") {
+    if (typeof elem_arg === "string") {
         // @ts-ignore
-        elem = Q(elem)[0];
+        elem = Q(elem_arg)[0];
         if (!elem) {
             console.log("Q.tags_input: elem " + elem_arg + " not found");
             return;

--- a/apps/tagged_posts/static/js/utils.js
+++ b/apps/tagged_posts/static/js/utils.js
@@ -272,8 +272,14 @@ Q.throttle = (callback, delay) => {
     return throttledEventHandler;
 };
 
-// parse a comma separated list of strings which may be quoted
+/**
+ * parse a comma separated list of strings which may be quoted
+ * @param {string} line
+ * @returns
+ */
 Q.parse_list = function (line) {
+    // handle empty string case
+    if (line.length === 0) return [];
     let a = [],
         i = 0,
         s = "",
@@ -314,9 +320,9 @@ Q.parse_list = function (line) {
 Q.tags_input = function (elem_arg, options) {
     /** @type {HTMLInputElement} */
     let elem;
-    if (typeof elem === "string") {
+    if (typeof elem_arg === "string") {
         // @ts-ignore
-        elem = Q(elem)[0];
+        elem = Q(elem_arg)[0];
         if (!elem) {
             console.log("Q.tags_input: elem " + elem_arg + " not found");
             return;

--- a/apps/todo/static/js/utils.js
+++ b/apps/todo/static/js/utils.js
@@ -272,8 +272,14 @@ Q.throttle = (callback, delay) => {
     return throttledEventHandler;
 };
 
-// parse a comma separated list of strings which may be quoted
+/**
+ * parse a comma separated list of strings which may be quoted
+ * @param {string} line
+ * @returns
+ */
 Q.parse_list = function (line) {
+    // handle empty string case
+    if (line.length === 0) return [];
     let a = [],
         i = 0,
         s = "",
@@ -314,9 +320,9 @@ Q.parse_list = function (line) {
 Q.tags_input = function (elem_arg, options) {
     /** @type {HTMLInputElement} */
     let elem;
-    if (typeof elem === "string") {
+    if (typeof elem_arg === "string") {
         // @ts-ignore
-        elem = Q(elem)[0];
+        elem = Q(elem_arg)[0];
         if (!elem) {
             console.log("Q.tags_input: elem " + elem_arg + " not found");
             return;


### PR DESCRIPTION
`utils.js` used to throw tons of errors using VSCode JS type checking.

This PR adds:
- JSDoc types and some ignores
- JSDoc docstrings for some functions
- Detection of bootstrap for Flash handling, and using bootstrap flash stuff if available
- in tags inputs, empty inputs aren't parsed as empty string tag `[""]`
- various other small changes to code to resolve type errors more nicely

I've mostly tested by clicking through the examples, but i may have missed something.