### PR TITLE
Fix login problem on Windows

### DIFF
--- a/py4web/utils/auth.py
+++ b/py4web/utils/auth.py
@@ -1673,8 +1673,12 @@ class DefaultAuthForms:
                 return form
 
             # If there are no errors, continue with the login process.
+
+            # Get plain text password directly from request, on Windows this is needed
+            # because form.vars.get("password", "") returns an hashed password.
+            plain_password = request.forms.get("password", "")
             user, error = self.auth.login(
-                form.vars.get("email", ""), form.vars.get("password", "")
+                form.vars.get("email", ""), plain_password
             )
             form.accepted = not error
 


### PR DESCRIPTION
Get plain text password directly from request.
On Windows this is needed because form.vars.get("password", "") returns an hashed password instead of the plain password. On Linux, instead, form.vars.get("password", "")  ==  request.forms.get("password", "")

It fix #987 