### PR TITLE
docs: Add Altcha captcha solution to manual

### DIFF
--- a/docs/chapter-16.rst
+++ b/docs/chapter-16.rst
@@ -816,7 +816,6 @@ You need to style the tags. For example:
       line-height: 1.2em;
       margin: 2px;
       cursor: pointer;
-      opacity: 0.2;
       text-transform: capitalize;
     }
     ul.tags-list li[data-selected=true] {
@@ -873,3 +872,152 @@ but the entire page will be redirected.
 
 The contents of the component html can contain `<script>...</script>` and they can modify global page variables
 as well as modify other components.
+
+.. _altcha_captcha:
+
+Adding a Captcha Solution with Altcha
+-------------------------------------
+
+This section provides a simple captcha implementation for your py4web applications using the **Altcha** library. While not exhaustively tested, it serves as a practical example for integrating a robust, client-side captcha solution.
+More information in https://altcha.org
+
+Prerequisites
+^^^^^^^^^^^^^
+
+First, you need to install the Altcha library. You can do this using pip:
+
+.. code-block:: bash
+
+   python3 -m pip install --upgrade altcha
+
+You also need a secret key for HMAC verification. It's recommended to store this in your application's settings. For this example, we'll assume you have a file like ``.settings.py`` with the following variable:
+
+.. code-block:: python
+
+   # .settings.py
+   ALTCHA_HMAC_KEY = "your-very-secret-key-here"
+
+Controller Logic
+^^^^^^^^^^^^^^^^
+
+Next, you need to add the necessary actions to your controller file. The following code provides two actions: one to generate the captcha challenge (``altcha``) and another to handle a form with the captcha (``some_form``).
+
+.. code-block:: python
+
+   # controllers/default.py
+   from altcha import (
+       create_challenge,
+       verify_solution,
+       ChallengeOptions,
+   )
+   from py4web import action, response, request, URL, Field, flash, Form
+   from py4web.utils.form import XML, T
+   from .settings import ALTCHA_HMAC_KEY
+
+   @action("altcha", method=["GET"])
+   def get_altcha():
+       """Generates and returns an Altcha challenge."""
+       try:
+           challenge = create_challenge(
+               ChallengeOptions(
+                   hmac_key=ALTCHA_HMAC_KEY,
+                   max_number=50000,
+               )
+           )
+           response.headers["Content-Type"] = "application/json"
+           return challenge.__dict__
+       except Exception as e:
+           response.status = 500
+           return {"error": f"Failed to create challenge: {str(e)}"}
+
+   @action.uses("form_altcha.html", session, flash)
+   def some_form():
+       """An example form that uses the Altcha captcha."""
+       fields = [
+           Field("name", requires=IS_NOT_EMPTY()),
+           Field("color", type="string", requires=IS_IN_SET(["red", "blue", "green"])),
+       ]
+       form = Form(fields,
+                   csrf_session=session,
+                   submit_button=T("Submit"))
+
+       # Insert the Altcha widget HTML before the submit button
+       form.structure.insert(-1, XML('<altcha-widget></altcha-widget></br>'))
+
+       if form.accepted:
+           altcha_payload = request.POST.get("altcha")
+           if not altcha_payload:
+               response.status = 400
+               flash.set("NO ALTCHA payload")
+               print("NO ALTCHA payload")
+           else:
+               ok, error = verify_solution(altcha_payload, ALTCHA_HMAC_KEY)
+               if not ok:
+                   response.status = 400
+                   flash.set(f"ALTCHA verification fail: {error}")
+                   print("ALTCHA verification fail:", error)
+               else:
+                   flash.set("ALTCHA verified.")
+
+       return dict(form=form)
+
+View Templates
+^^^^^^^^^^^^^^
+
+You need to include the Altcha JavaScript library and configure the widget in your HTML templates.
+
+``form_altcha.html``
+""""""""""""""""""""
+
+This template works with the ``some_form`` action. It loads the Altcha script and sets the ``challengeurl`` attribute to point to our ``altcha`` action.
+
+.. code-block:: html
+
+   [[extend 'layout.html']]
+
+   <script async defer src="https://cdn.jsdelivr.net/gh/altcha-org/altcha/dist/altcha.min.js" type="module"></script>
+   <script>
+       document.addEventListener("DOMContentLoaded", function () {
+           const altchaWidget = document.querySelector("altcha-widget");
+           if (altchaWidget) {
+               altchaWidget.setAttribute("challengeurl", "[[=URL('altcha')]]");
+           }
+       });
+   </script>
+   <div class="section">
+       <div class="vars">[[=form]]</div>
+   </div>
+
+Custom Auth Form
+""""""""""""""""
+
+For a custom authentication form, you can follow a similar approach. Make sure to insert the ``<altcha-widget>`` tag into the form's structure and include the necessary JavaScript.
+
+.. code-block:: html
+
+   [[extend "layout.html"]]
+   <script async defer src="https://cdn.jsdelivr.net/gh/altcha-org/altcha/dist/altcha.min.js" type="module"></script>
+
+   <script>
+       document.addEventListener("DOMContentLoaded", function () {
+           const altchaWidget = document.querySelector("altcha-widget");
+           if (altchaWidget) {
+               altchaWidget.setAttribute("challengeurl", "[[=URL('altcha')]]");
+           }
+       });
+   </script>
+   <style>
+       .auth-container {
+           max-width: 80%;
+           min-width: 400px;
+           margin-left: auto;
+           margin-right: auto;
+           border: 1px solid #e1e1e1;
+           border-radius: 10px;
+           padding: 20px;
+       }
+   </style>
+
+   [[form.structure.insert(-1,XML('<altcha-widget></altcha-widget></br>'))]]
+
+   <div class="auth-container">[[=form]]</div>


### PR DESCRIPTION
This PR adds a new section to the py4web manual (chapter 16) that explains how to integrate a simple, client-side captcha solution using the Altcha library.

The new section includes:

Instructions on how to install the Altcha library.

Example controller code to generate and verify the captcha challenge.

Corresponding template code to display the Altcha widget.

This contribution provides a practical, ready-to-use example for developers who need to add a basic captcha to their py4web forms.