### PR TITLE
fix docs about db field fixture thread safety, point to the updated docs

### DIFF
--- a/docs/chapter-06.rst
+++ b/docs/chapter-06.rst
@@ -833,13 +833,8 @@ after submit, additional code needs to be added, as we will see later
 on. This example is assuming that you created the application from the
 scaffolding app, so that a generic.html is already created for you.
 
-The ``readable``, ``writable``, ``default``, ``update``, and ``require``
-attributes of ``db.{table}.{field}`` are special objects of class
-``ThreadSafeVariable`` defined the ``threadsafevariable`` module. These
-objects are very much like Python thread local objects but they are
-re-initialized at every request using the value specified outside of the
-action. This means that actions can safely change the values of these
-attributes.
+The full list of database field attributes which can be changed safely 
+is found here: :ref:`Thread safety and Field attributes`
 
 Custom fixtures
 ---------------


### PR DESCRIPTION
At some point I updated the docs about db field thread safety, but apparently forgot this. I just stumbled across it and fixed it.