### PR TITLE
README: venv code example minor fix.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,8 +67,8 @@ You can use a virtual environment:
 
    $ python -m venv .venv
    $ . .venv/bin/activate
-   $ pip install --upgrade --no-cache-dir
-   $ py4web setup apps
+   $ pip install --upgrade --no-cache-dir py4web   
+   $ py4web setup --yes apps
    ...
    $ py4web run apps
 


### PR DESCRIPTION
added package name to install command in venv example. Currently "py4web" is missing from the pip install command in the venv example.

Used the venv example to offer example usage of --yes flag.