### PR TITLE
Update core.py for double url prefix

### DIFF
--- a/py4web/core.py
+++ b/py4web/core.py
@@ -899,6 +899,8 @@ def URL(  # pylint: disable=invalid-name
             broken_parts.insert(1, "_" + static_version)
 
     url_prefix = os.environ.get("PY4WEB_URL_PREFIX", "")
+    if url_prefix and prefix and prefix.startswith(url_prefix):
+        url_prefix = ""
     url = (
         url_prefix
         + prefix


### PR DESCRIPTION
When using a url_prefix, the prefix is doubled when using the _dashboard database app.
dbadmin.html uses a grid object which parses the url and adds the prefix twice to the url.

My change checks to see if the url_prefix is already in the prefix, and will only add it if it isn't.