### PR TITLE
Move the horizontal scrollbar from the table to the page body

### DIFF
--- a/apps/_dashboard/static/css/no.css
+++ b/apps/_dashboard/static/css/no.css
@@ -46,10 +46,6 @@ body {
   grid-template-rows: auto 1fr auto;
 }
 
-body > center, body > center > main {
-  width: 100vw;
-}
-
 /****************************************************
  elements style
  ****************************************************/
@@ -587,8 +583,15 @@ nav { width: auto; }
 .dbadmin .grid-td { max-width: 300px !important; overflow: hidden !important; text-overflow: ellipsis !important; white-space: nowrap !important; }
 .dbadmin .grid-td:last-child {text-align: right}
 .dbadmin .grid-table-wrapper { overflow-x: auto; }
-.dbadmin div:has(> flash-alerts) { height: 6px; }
 .dbadmin h2 { margin-top: 0px; font-size: 1.5em; }
 .dbadmin .grid-search-form-table { width: 70vw; }
 .dbadmin .grid-search-form-tr:hover { background-color: transparent; }
 .dbadmin td, .dbadmin th { padding: 1px 8px; }
+.dbadmin .grid-table-wrapper { overflow-x: visible; }
+
+html:has(.dbadmin),
+body:has(.dbadmin) {
+    overflow-x: visible;
+}
+
+div:has(> flash-alerts) { height: 6px; }


### PR DESCRIPTION
The PR is optional. It helps ensure that the horizontal scrollbar is visible even on smaller screens, such as laptop displays, without requiring users to scroll down.

One could argue that on laptops, users can scroll to the right using the touchpad, so there is no need for the horizontal scrollbar to be visible. This is a valid point, but I still think it would be preferable to show the scrollbar. That way, users can immediately see that there are additional columns to the right that are not currently visible, rather than having to scroll down and discover this from the horizontal bar at the bottom of the table.