### PR TITLE
Fix upload the file into blob field by using class Form

### DIFF
--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -924,7 +924,7 @@ class Form(object):
                             validated_vars[field.name] = self.record.get(field.name)
                         else:
                             validated_vars[field.name] = value = None
-                    if isinstance(field.uploadfield, str):
+                    if isinstance(field.uploadfield, str) and value is not None:
                         validated_vars[field.uploadfield] = value.file.read()
                 elif field.type == 'blob':
                     pass

--- a/py4web/utils/form.py
+++ b/py4web/utils/form.py
@@ -924,6 +924,10 @@ class Form(object):
                             validated_vars[field.name] = self.record.get(field.name)
                         else:
                             validated_vars[field.name] = value = None
+                    if isinstance(field.uploadfield, str):
+                        validated_vars[field.uploadfield] = value.file.read()
+                elif field.type == 'blob':
+                    pass
                 elif field.type == "boolean":
                     validated_vars[field.name] = value is not None
                 else:


### PR DESCRIPTION
Fix to be able to actually upload a file into blob field by using class Form.

Given table definition as below
```
db.define_table('products',
    Field('name', 'string', length=50),
    Field('image', 'upload', uploadfield='image_data'),
    Field('image_data', 'blob', default=''))
```

and respective action
```
@action("new_product", method=["POST", "GET"])
@action.uses("new_product.html")
def new_product():
    form = Form(db.products)
    if form.accepted:
        redirect(URL('index'))
return dict(form=form)
```
when submitting the form,  `image_data` column in database was always `null`.

The fix is just a copy of solution used in **web2py**.